### PR TITLE
DART now supports mimic joints (v>=6.7)

### DIFF
--- a/src/robot_dart/control/pd_control.cpp
+++ b/src/robot_dart/control/pd_control.cpp
@@ -20,17 +20,16 @@ namespace robot_dart {
         {
             ROBOT_DART_ASSERT(_control_dof == _ctrl.size(), "PDControl: Controller parameters size is not the same as DOFs of the robot", Eigen::VectorXd::Zero(_control_dof));
             auto robot = _robot.lock();
-            Eigen::VectorXd target_positions = Eigen::VectorXd::Zero(_dof);
-            target_positions.tail(_control_dof) = Eigen::VectorXd::Map(_ctrl.data(), _ctrl.size());
+            Eigen::VectorXd target_positions = Eigen::VectorXd::Map(_ctrl.data(), _ctrl.size());
 
-            Eigen::VectorXd q = robot->skeleton()->getPositions();
-            Eigen::VectorXd dq = robot->skeleton()->getVelocities();
+            Eigen::VectorXd q = get_positions();
+            Eigen::VectorXd dq = get_velocities();
 
             /// Compute the simplest PD controller output:
             /// P gain * (target position - current position) + D gain * (0 - current velocity)
             Eigen::VectorXd commands = _Kp.array() * (target_positions.array() - q.array()) - _Kd.array() * dq.array();
 
-            return commands.tail(_control_dof);
+            return commands;
         }
 
         void PDControl::set_pd(double Kp, double Kd)

--- a/src/robot_dart/control/robot_control.cpp
+++ b/src/robot_dart/control/robot_control.cpp
@@ -30,6 +30,16 @@ namespace robot_dart {
             if (robot->free() && !_full_control)
                 _start_dof = 6;
             _control_dof = _dof - _start_dof;
+#if DART_MAJOR_VERSION > 6 || (DART_MAJOR_VERSION == 6 && DART_MINOR_VERSION > 6)
+            _mimic_dofs.clear();
+            for (size_t i = _start_dof; i < robot->skeleton()->getNumDofs(); i++) {
+                auto joint = robot->skeleton()->getDof(i)->getJoint();
+                if (joint->getActuatorType() == dart::dynamics::Joint::MIMIC)
+                    _mimic_dofs.push_back(i);
+            }
+
+            _control_dof -= _mimic_dofs.size();
+#endif
 
             for (size_t i = 0; i < _start_dof; i++)
                 robot->skeleton()->getDof(i)->getJoint()->setActuatorType(dart::dynamics::Joint::FORCE);
@@ -82,12 +92,87 @@ namespace robot_dart {
             _weight = weight;
         }
 
+        Eigen::VectorXd RobotControl::get_positions() const
+        {
+            return _get_vector_mimic(_robot.lock()->skeleton()->getPositions());
+        }
+
+        void RobotControl::set_positions(const Eigen::VectorXd& positions)
+        {
+            _robot.lock()->skeleton()->setPositions(_set_vector_mimic(positions));
+        }
+
+        Eigen::VectorXd RobotControl::get_velocities() const
+        {
+            return _get_vector_mimic(_robot.lock()->skeleton()->getVelocities());
+        }
+
+        void RobotControl::set_velocities(const Eigen::VectorXd& velocities)
+        {
+            _robot.lock()->skeleton()->setVelocities(_set_vector_mimic(velocities));
+        }
+
+        Eigen::VectorXd RobotControl::get_accelerations() const
+        {
+            return _get_vector_mimic(_robot.lock()->skeleton()->getAccelerations());
+        }
+
+        void RobotControl::set_accelerations(const Eigen::VectorXd& accelerations)
+        {
+            _robot.lock()->skeleton()->setAccelerations(_set_vector_mimic(accelerations));
+        }
+
+        Eigen::VectorXd RobotControl::get_forces() const
+        {
+            return _get_vector_mimic(_robot.lock()->skeleton()->getForces());
+        }
+
+        void RobotControl::set_forces(const Eigen::VectorXd& forces)
+        {
+            _robot.lock()->skeleton()->setForces(_set_vector_mimic(forces));
+        }
+
         Eigen::VectorXd RobotControl::commands(double t)
         {
-            Eigen::VectorXd coms = Eigen::VectorXd::Zero(_dof);
-            coms.tail(_control_dof) = calculate(t);
+            Eigen::VectorXd coms = _set_vector_mimic(calculate(t));
 
             return coms;
+        }
+
+        Eigen::VectorXd RobotControl::_get_vector_mimic(const Eigen::VectorXd& vec) const
+        {
+#if DART_MAJOR_VERSION > 6 || (DART_MAJOR_VERSION == 6 && DART_MINOR_VERSION > 6)
+            Eigen::VectorXd ret = Eigen::VectorXd::Zero(_control_dof);
+            size_t k = 0;
+            for (size_t i = _start_dof; i < _dof; i++) {
+                auto it = std::find(_mimic_dofs.begin(), _mimic_dofs.end(), i);
+                if (it == _mimic_dofs.end())
+                    ret(k++) = vec(i);
+            }
+
+            return ret;
+#else
+            return vec.tail(_control_dof);
+#endif
+        }
+
+        Eigen::VectorXd RobotControl::_set_vector_mimic(const Eigen::VectorXd& vec) const
+        {
+#if DART_MAJOR_VERSION > 6 || (DART_MAJOR_VERSION == 6 && DART_MINOR_VERSION > 6)
+            Eigen::VectorXd ret = Eigen::VectorXd::Zero(_dof);
+            size_t k = 0;
+            for (size_t i = _start_dof; i < _dof; i++) {
+                auto it = std::find(_mimic_dofs.begin(), _mimic_dofs.end(), i);
+                if (it == _mimic_dofs.end())
+                    ret(i) = vec(k++);
+            }
+
+            return ret;
+#else
+            Eigen::VectorXd ret = Eigen::VectorXd::Zero(_dof);
+            ret.tail(_control_dof) = vec;
+            return ret;
+#endif
         }
     } // namespace control
 } // namespace robot_dart

--- a/src/robot_dart/control/robot_control.hpp
+++ b/src/robot_dart/control/robot_control.hpp
@@ -6,6 +6,8 @@
 #include <memory>
 #include <vector>
 
+#include <dart/config.hpp>
+
 namespace robot_dart {
     class Robot;
 
@@ -39,12 +41,30 @@ namespace robot_dart {
             virtual Eigen::VectorXd calculate(double t) = 0;
             virtual std::shared_ptr<RobotControl> clone() const = 0;
 
+            Eigen::VectorXd get_positions() const;
+            void set_positions(const Eigen::VectorXd& positions);
+
+            Eigen::VectorXd get_velocities() const;
+            void set_velocities(const Eigen::VectorXd& velocities);
+
+            Eigen::VectorXd get_accelerations() const;
+            void set_accelerations(const Eigen::VectorXd& accelerations);
+
+            Eigen::VectorXd get_forces() const;
+            void set_forces(const Eigen::VectorXd& forces);
+
         protected:
             std::weak_ptr<Robot> _robot;
             std::vector<double> _ctrl;
             double _weight;
             bool _active, _full_control;
             size_t _start_dof, _dof, _control_dof;
+#if DART_MAJOR_VERSION > 6 || (DART_MAJOR_VERSION == 6 && DART_MINOR_VERSION > 6)
+            std::vector<size_t> _mimic_dofs;
+
+            Eigen::VectorXd _get_vector_mimic(const Eigen::VectorXd& vec) const;
+            Eigen::VectorXd _set_vector_mimic(const Eigen::VectorXd& vec) const;
+#endif
         };
     } // namespace control
 } // namespace robot_dart


### PR DESCRIPTION
DART now supports mimic joints (v>=6.7). This PR introduces small changes in robot control to take into account that mimic joints should not be controlled..