### PR TITLE
new camera management

### DIFF
--- a/src/examples/cameras.cpp
+++ b/src/examples/cameras.cpp
@@ -33,6 +33,8 @@ int main()
     std::srand(std::time(NULL));
     auto global_robot = std::make_shared<robot_dart::Robot>("res/models/arm.urdf");
 
+    robot_dart::graphics::PbufferManager::createPbufferManager(3);
+    
     global_robot->fix_to_world();
     global_robot->set_position_enforced(true);
     // g_robot->skeleton()->setPosition(1, M_PI / 2.0);

--- a/src/robot_dart/graphics/camera_osr.hpp
+++ b/src/robot_dart/graphics/camera_osr.hpp
@@ -8,6 +8,7 @@
 
 #include <dart/gui/osg/osg.hpp>
 
+#include <osg/Version>
 #include <osgDB/WriteFile>
 
 namespace robot_dart {
@@ -29,7 +30,7 @@ namespace robot_dart {
                 width = vp->width();
                 height = vp->height();
 
-                _viewer->image()->readPixels(x, y, width, height, GL_LUMINANCE, GL_UNSIGNED_BYTE);
+                _viewer->image()->readPixels(x, y, width, height, GL_RGB, GL_UNSIGNED_BYTE);
 
                 if (_viewer->recording()) {
                     if (!_viewer->filename().empty()) {
@@ -52,14 +53,13 @@ namespace robot_dart {
             CameraOSR(const dart::simulation::WorldPtr& world, unsigned int width = 640, unsigned int height = 480, bool shadowed = true) : _world(world), _width(width), _height(height), _frame_counter(0), _enabled(true), _buffer_valid(true), _recording(false), _filename("camera_record.png"), _image(new osg::Image), _shot_done(false)
 
             {
-                if (!global::pbufferManager) {
-                    std::cout << "Error: pbufferManager seems not to be started" << std::endl;
-                    assert(0);
-                }
+                ROBOT_DART_EXCEPTION_ASSERT(global::pbufferManager, "Error: pbufferManager seems not to be started!");
 
                 _osg_viewer = new dart::gui::osg::Viewer;
                 _osg_viewer->setThreadingModel(osgViewer::ViewerBase::ThreadingModel::SingleThreaded);
+#if OPENSCENEGRAPH_MAJOR_VERSION > 3 || (OPENSCENEGRAPH_MAJOR_VERSION == 3 && OPENSCENEGRAPH_MINOR_VERSION >= 6)
                 _osg_viewer->setUseConfigureAffinity(false);
+#endif
                 _pbuffer = global::pbufferManager->get_pbuffer();
 
                 if (_pbuffer.valid()) {

--- a/src/robot_dart/graphics/camera_osr.hpp
+++ b/src/robot_dart/graphics/camera_osr.hpp
@@ -3,12 +3,12 @@
 #include <unistd.h>
 
 #include <robot_dart/graphics/base_graphics.hpp>
+#include <robot_dart/graphics/pbuffer_manager.hpp>
 #include <robot_dart/utils.hpp>
 
 #include <dart/gui/osg/osg.hpp>
 
 #include <osgDB/WriteFile>
-#include "pbuffer_manager.hpp"
 
 namespace robot_dart {
     namespace graphics {
@@ -37,7 +37,7 @@ namespace robot_dart {
                         ROBOT_DART_WARNING(!saved, "GetScreen unable to save image to file '" + _viewer->filename() + "'");
                     }
                 }
-		_viewer->set_shot_done(true);
+                _viewer->set_shot_done(true);
             }
 
         protected:
@@ -49,20 +49,19 @@ namespace robot_dart {
         class CameraOSR : public BaseGraphics {
 
         public:
-	  CameraOSR(const dart::simulation::WorldPtr& world, unsigned int width = 640, unsigned int height = 480, bool shadowed = true) : _world(world), _width(width), _height(height), _frame_counter(0), _enabled(true), _buffer_valid(true), _recording(false), _filename("camera_record.png"), _image(new osg::Image),_shot_done(false)
+            CameraOSR(const dart::simulation::WorldPtr& world, unsigned int width = 640, unsigned int height = 480, bool shadowed = true) : _world(world), _width(width), _height(height), _frame_counter(0), _enabled(true), _buffer_valid(true), _recording(false), _filename("camera_record.png"), _image(new osg::Image), _shot_done(false)
 
             {
-	      if(!global::pbufferManager)
-		{
-		  std::cout<< "Error: pbufferManager seems not to be started"<<std::endl;
-		  assert(0);
-		}
-	      
-	      _osg_viewer = new dart::gui::osg::Viewer;
-	      _osg_viewer->setThreadingModel(osgViewer::ViewerBase::ThreadingModel::SingleThreaded);
-	      _osg_viewer->setUseConfigureAffinity(false);
-	      _pbuffer = global::pbufferManager->get_pbuffer();
-		
+                if (!global::pbufferManager) {
+                    std::cout << "Error: pbufferManager seems not to be started" << std::endl;
+                    assert(0);
+                }
+
+                _osg_viewer = new dart::gui::osg::Viewer;
+                _osg_viewer->setThreadingModel(osgViewer::ViewerBase::ThreadingModel::SingleThreaded);
+                _osg_viewer->setUseConfigureAffinity(false);
+                _pbuffer = global::pbufferManager->get_pbuffer();
+
                 if (_pbuffer.valid()) {
                     ::osg::ref_ptr<osg::Camera> camera = _osg_viewer->getCamera();
                     camera->setGraphicsContext(_pbuffer.get());
@@ -83,23 +82,22 @@ namespace robot_dart {
                     ROBOT_DART_WARNING(true, "Error configuring pbuffer in CameraOSR! Camera will be disabled!");
                     _enabled = false;
                     _buffer_valid = false;
-		}
+                }
             }
 
             ~CameraOSR()
             {
                 _osg_viewer->removeWorldNode(_osg_world_node); // This line fixes a memory leak from DART
-		// This following lines will still be necessary after DART fixes their side. 
-		_osg_viewer->getCamera()->setFinalDrawCallback(0);
-		_osg_viewer->getCamera()->setGraphicsContext(0);
-		_osg_world_node=NULL;
-		_osg_viewer=NULL;
-		_image=NULL;
-		
-		global::pbufferManager->release_pbuffer(_pbuffer);
-		_pbuffer=NULL;
-	  }
+                // This following lines will still be necessary after DART fixes their side.
+                _osg_viewer->getCamera()->setFinalDrawCallback(0);
+                _osg_viewer->getCamera()->setGraphicsContext(0);
+                _osg_world_node = NULL;
+                _osg_viewer = NULL;
+                _image = NULL;
 
+                global::pbufferManager->release_pbuffer(_pbuffer);
+                _pbuffer = NULL;
+            }
 
             bool done() const override
             {
@@ -126,15 +124,15 @@ namespace robot_dart {
             {
                 if (!_buffer_valid)
                     return;
-		_shot_done=false;
+                _shot_done = false;
                 if (!_osg_viewer->isRealized()) {
                     _osg_viewer->realize();
                 }
                 _osg_viewer->frame();
             }
 
-	  bool shot_done()const{return _shot_done;}
-	  void set_shot_done(bool val){_shot_done = val;}
+            bool shot_done() const { return _shot_done; }
+            void set_shot_done(bool val) { _shot_done = val; }
             void set_render_period(double dt) override
             {
                 // we want to display at around 60Hz of simulated time
@@ -181,7 +179,7 @@ namespace robot_dart {
             Eigen::Vector3d _camera_up;
             osg::ref_ptr<dart::gui::osg::WorldNode> _osg_world_node;
             osg::ref_ptr<dart::gui::osg::Viewer> _osg_viewer;
-	  ::osg::ref_ptr<::osg::GraphicsContext> _pbuffer;
+            ::osg::ref_ptr<::osg::GraphicsContext> _pbuffer;
             dart::simulation::WorldPtr _world;
             size_t _render_period, _width, _height, _frame_counter;
             bool _enabled, _buffer_valid;
@@ -189,7 +187,7 @@ namespace robot_dart {
             std::string _filename;
 
             osg::ref_ptr<osg::Image> _image;
-	  bool _shot_done;
+            bool _shot_done;
         };
 
     } // namespace graphics

--- a/src/robot_dart/graphics/pbuffer_manager.hpp
+++ b/src/robot_dart/graphics/pbuffer_manager.hpp
@@ -4,6 +4,8 @@
 #include <memory>
 #include <mutex>
 
+#include <robot_dart/utils.hpp>
+
 #include <dart/gui/osg/osg.hpp>
 
 namespace robot_dart {
@@ -55,36 +57,25 @@ namespace robot_dart {
                 std::lock_guard<std::mutex> lock(g_i_mutex);
                 while (it != _pbuffers.end() && it->second == true)
                     it++;
-                if (it == _pbuffers.end()) {
-                    std::cout << "All the pbuffers are already used... Please create more" << std::endl;
-                    assert(0);
-                }
-                else {
-                    it->second = true;
-                    //just checking
-                    if (_pbuffers[it->first] != true) {
-                        std::cout << "State not changed in the pbuffer map" << std::endl;
-                        assert(0);
-                    }
-                    return it->first;
-                }
+                ROBOT_DART_EXCEPTION_ASSERT(it != _pbuffers.end(), "All the pbuffers are already used... Please create more!");
+
+                it->second = true;
+
+                ROBOT_DART_EXCEPTION_ASSERT(_pbuffers[it->first], "State not changed in the pbuffer map!");
+
+                return it->first;
             }
 
             void release_pbuffer(::osg::ref_ptr<::osg::GraphicsContext> pbuffer)
             {
                 std::lock_guard<std::mutex> lock(g_i_mutex);
                 auto it = _pbuffers.find(pbuffer);
-                if (it == _pbuffers.end()) {
-                    std::cout << "Pbuffer not found in the pbuffer map" << std::endl;
-                    assert(0);
-                }
-                else
-                    it->second = false;
+                ROBOT_DART_EXCEPTION_ASSERT(it != _pbuffers.end(), "Pbuffer not found in the pbuffer map!");
+
+                it->second = false;
             }
 
-            ~PbufferManager()
-            {
-            }
+            ~PbufferManager() {}
 
         protected:
             size_t _nb_threads;

--- a/src/robot_dart/graphics/pbuffer_manager.hpp
+++ b/src/robot_dart/graphics/pbuffer_manager.hpp
@@ -1,30 +1,31 @@
 #ifndef ROBOT_DART_GRAPHICS_PBUFFER_MANAGER_HPP
 #define ROBOT_DART_GRAPHICS_PBUFFER_MANAGER_HPP
 
-#include <mutex>
 #include <memory>
+#include <mutex>
 
 #include <dart/gui/osg/osg.hpp>
+
 namespace robot_dart {
     namespace graphics {
 
-      class PbufferManager;
-      
-      namespace global{
-	std::unique_ptr<PbufferManager> pbufferManager;
-      }
-      
-      
+        class PbufferManager;
+
+        namespace global {
+            std::unique_ptr<PbufferManager> pbufferManager;
+        }
+
         // PBuffer manager: used to create and allocate pbuffer to different thread to avoid creating multiple buffers at the same time
         class PbufferManager {
 
         public:
-	  static void createPbufferManager(size_t nb_threads = 8){
-	    ::osg::setNotifyLevel(::osg::WARN); // used to remove INFO messages that are coming from realising a context already realized
-	    global::pbufferManager = std::unique_ptr<PbufferManager>(new PbufferManager(nb_threads));
-	  }
-	  
-	  PbufferManager(size_t nb_threads = 8):_nb_threads(nb_threads)
+            static void createPbufferManager(size_t nb_threads = 8)
+            {
+                ::osg::setNotifyLevel(::osg::WARN); // used to remove INFO messages that are coming from realising a context already realized
+                global::pbufferManager = std::unique_ptr<PbufferManager>(new PbufferManager(nb_threads));
+            }
+
+            PbufferManager(size_t nb_threads = 8) : _nb_threads(nb_threads)
             {
                 //graphics context
                 ::osg::ref_ptr<::osg::GraphicsContext::Traits> traits = new ::osg::GraphicsContext::Traits;
@@ -44,60 +45,54 @@ namespace robot_dart {
                 traits->doubleBuffer = true;
                 traits->sharedContext = 0;
                 traits->setUndefinedScreenDetailsToDefaultScreen();
-		for(size_t i=0; i<_nb_threads; i++)
-		  _pbuffers[::osg::GraphicsContext::createGraphicsContext(traits.get())]=false;
-		
+                for (size_t i = 0; i < _nb_threads; i++)
+                    _pbuffers[::osg::GraphicsContext::createGraphicsContext(traits.get())] = false;
             }
 
-	  ::osg::ref_ptr<::osg::GraphicsContext> get_pbuffer()
-	  {
-	    auto it=_pbuffers.begin();
-	    std::lock_guard<std::mutex> lock(g_i_mutex);
-	    while(it!=_pbuffers.end() && it->second==true)
-	      it++;
-	    if(it == _pbuffers.end())
-	      {
-		std::cout<<"All the pbuffers are already used... Please create more"<<std::endl;
-		assert(0);
-	      }
-	    else
-	      {
-		it->second = true;
-		//just checking
-		if(_pbuffers[it->first]!=true)
-		  {
-		    std::cout<<"State not changed in the pbuffer map"<<std::endl;
-		    assert(0);
-		  }
-		return it->first;
-	      }
-	  }
+            ::osg::ref_ptr<::osg::GraphicsContext> get_pbuffer()
+            {
+                auto it = _pbuffers.begin();
+                std::lock_guard<std::mutex> lock(g_i_mutex);
+                while (it != _pbuffers.end() && it->second == true)
+                    it++;
+                if (it == _pbuffers.end()) {
+                    std::cout << "All the pbuffers are already used... Please create more" << std::endl;
+                    assert(0);
+                }
+                else {
+                    it->second = true;
+                    //just checking
+                    if (_pbuffers[it->first] != true) {
+                        std::cout << "State not changed in the pbuffer map" << std::endl;
+                        assert(0);
+                    }
+                    return it->first;
+                }
+            }
 
-	  void release_pbuffer(::osg::ref_ptr<::osg::GraphicsContext> pbuffer){
-	    std::lock_guard<std::mutex> lock(g_i_mutex);
-	    auto it = _pbuffers.find(pbuffer);
-	    if (it == _pbuffers.end())
-	      {
-		std::cout<<"Pbuffer not found in the pbuffer map"<<std::endl;
-                assert(0);
-	      }
-	    else
-	      it->second=false;
-	  }
-	  
-	  ~PbufferManager()
-	  {
-	  }
-	  
+            void release_pbuffer(::osg::ref_ptr<::osg::GraphicsContext> pbuffer)
+            {
+                std::lock_guard<std::mutex> lock(g_i_mutex);
+                auto it = _pbuffers.find(pbuffer);
+                if (it == _pbuffers.end()) {
+                    std::cout << "Pbuffer not found in the pbuffer map" << std::endl;
+                    assert(0);
+                }
+                else
+                    it->second = false;
+            }
+
+            ~PbufferManager()
+            {
+            }
 
         protected:
-	  size_t _nb_threads;
-	  // if the value is true, this means that the pbuffer has been given to a thread. 
-	  std::map<::osg::ref_ptr<::osg::GraphicsContext>, bool> _pbuffers;
-	  
-	  std::mutex g_i_mutex;
+            size_t _nb_threads;
+            // if the value is true, this means that the pbuffer has been given to a thread.
+            std::map<::osg::ref_ptr<::osg::GraphicsContext>, bool> _pbuffers;
+
+            std::mutex g_i_mutex;
         };
-      
 
     } // namespace graphics
 } // namespace robot_dart

--- a/src/robot_dart/graphics/pbuffer_manager.hpp
+++ b/src/robot_dart/graphics/pbuffer_manager.hpp
@@ -1,0 +1,104 @@
+#ifndef ROBOT_DART_GRAPHICS_PBUFFER_MANAGER_HPP
+#define ROBOT_DART_GRAPHICS_PBUFFER_MANAGER_HPP
+
+#include <mutex>
+#include <memory>
+
+#include <dart/gui/osg/osg.hpp>
+namespace robot_dart {
+    namespace graphics {
+
+      class PbufferManager;
+      
+      namespace global{
+	std::unique_ptr<PbufferManager> pbufferManager;
+      }
+      
+      
+        // PBuffer manager: used to create and allocate pbuffer to different thread to avoid creating multiple buffers at the same time
+        class PbufferManager {
+
+        public:
+	  static void createPbufferManager(size_t nb_threads = 8){
+	    global::pbufferManager = std::unique_ptr<PbufferManager>(new PbufferManager(nb_threads));
+	  }
+	  
+	  PbufferManager(size_t nb_threads = 8):_nb_threads(nb_threads)
+            {
+                //graphics context
+                ::osg::ref_ptr<::osg::GraphicsContext::Traits> traits = new ::osg::GraphicsContext::Traits;
+                traits->readDISPLAY();
+
+                traits->x = 0;
+                traits->y = 0;
+                traits->width = 512;
+                traits->height = 512;
+                traits->red = 8;
+                traits->green = 8;
+                traits->blue = 8;
+                traits->alpha = 0;
+                //traits->depth = 24;
+                traits->windowDecoration = false;
+                traits->pbuffer = true;
+                traits->doubleBuffer = true;
+                traits->sharedContext = 0;
+                traits->setUndefinedScreenDetailsToDefaultScreen();
+		for(size_t i=0; i<_nb_threads; i++)
+		  _pbuffers[::osg::GraphicsContext::createGraphicsContext(traits.get())]=false;
+		
+            }
+
+	  ::osg::ref_ptr<::osg::GraphicsContext> get_pbuffer()
+	  {
+	    auto it=_pbuffers.begin();
+	    std::lock_guard<std::mutex> lock(g_i_mutex);
+	    while(it!=_pbuffers.end() && it->second==true)
+	      it++;
+	    if(it == _pbuffers.end())
+	      {
+		std::cout<<"All the pbuffers are already used... Please create more"<<std::endl;
+		assert(0);
+	      }
+	    else
+	      {
+		it->second = true;
+		//just checking
+		if(_pbuffers[it->first]!=true)
+		  {
+		    std::cout<<"State not changed in the pbuffer map"<<std::endl;
+		    assert(0);
+		  }
+		return it->first;
+	      }
+	  }
+
+	  void release_pbuffer(::osg::ref_ptr<::osg::GraphicsContext> pbuffer){
+	    std::lock_guard<std::mutex> lock(g_i_mutex);
+	    auto it = _pbuffers.find(pbuffer);
+	    if (it == _pbuffers.end())
+	      {
+		std::cout<<"Pbuffer not found in the pbuffer map"<<std::endl;
+                assert(0);
+	      }
+	    else
+	      it->second=false;
+	  }
+	  
+	  ~PbufferManager()
+	  {
+	  }
+	  
+
+        protected:
+	  size_t _nb_threads;
+	  // if the value is true, this means that the pbuffer has been given to a thread. 
+	  std::map<::osg::ref_ptr<::osg::GraphicsContext>, bool> _pbuffers;
+	  
+	  std::mutex g_i_mutex;
+        };
+      
+
+    } // namespace graphics
+} // namespace robot_dart
+
+#endif

--- a/src/robot_dart/graphics/pbuffer_manager.hpp
+++ b/src/robot_dart/graphics/pbuffer_manager.hpp
@@ -20,6 +20,7 @@ namespace robot_dart {
 
         public:
 	  static void createPbufferManager(size_t nb_threads = 8){
+	    ::osg::setNotifyLevel(::osg::WARN); // used to remove INFO messages that are coming from realising a context already realized
 	    global::pbufferManager = std::unique_ptr<PbufferManager>(new PbufferManager(nb_threads));
 	  }
 	  


### PR DESCRIPTION
See #21 

This PR adds a different way to manage pbuffer used by the cameras. 

**This is still WIP.** 

It requires OSG>=3.6 (to have osgViewer::ViewerBase::setUseConfigureAffinity(bool flag) function), I will probably put this into a `#ifdef` to make it optional. 

Opinions, comments, and ideas are welcome. 

