### PR TITLE
change visuals of materials

### DIFF
--- a/src/examples/meshes.cpp
+++ b/src/examples/meshes.cpp
@@ -20,6 +20,10 @@ int main()
 
     global_robot->fix_to_world();
     global_robot->set_position_enforced(true);
+    // Use the material information coming from the meshes instead of the URDF file
+    // global_robot->set_color_mode(dart::dynamics::MeshShape::ColorMode::MATERIAL_COLOR);
+    // Use the material information from the meshes only for a specific BodyNode
+    // global_robot->set_color_mode(dart::dynamics::MeshShape::ColorMode::MATERIAL_COLOR, "iiwa_link_6");
 
     std::vector<double> ctrl;
     ctrl = {0., M_PI / 3., 0., -M_PI / 4., 0., 0., 0.};

--- a/src/robot_dart/robot.cpp
+++ b/src/robot_dart/robot.cpp
@@ -33,7 +33,6 @@ namespace robot_dart {
     {
         ROBOT_DART_EXCEPTION_INTERNAL_ASSERT(_skeleton != nullptr);
         _set_damages(damages);
-        set_color_mode(dart::dynamics::MeshShape::ColorMode::SHAPE_COLOR);
     }
 
     Robot::Robot(const std::string& model_file, const std::string& robot_name, bool is_urdf_string, std::vector<RobotDamage> damages) : Robot(model_file, std::vector<std::pair<std::string, std::string>>(), robot_name, is_urdf_string, damages) {}
@@ -43,7 +42,6 @@ namespace robot_dart {
         ROBOT_DART_EXCEPTION_INTERNAL_ASSERT(_skeleton != nullptr);
         _skeleton->setName(robot_name);
         _set_damages(damages);
-        set_color_mode(dart::dynamics::MeshShape::ColorMode::SHAPE_COLOR);
     }
 
     std::shared_ptr<Robot> Robot::clone() const
@@ -323,13 +321,7 @@ namespace robot_dart {
 
     void Robot::set_color_mode(dart::dynamics::MeshShape::ColorMode color_mode)
     {
-        for (size_t i = 0; i < _skeleton->getNumBodyNodes(); ++i) {
-            dart::dynamics::BodyNode* bn = _skeleton->getBodyNode(i);
-            for (size_t j = 0; j < bn->getNumShapeNodes(); ++j) {
-                dart::dynamics::ShapeNode* sn = bn->getShapeNode(j);
-                _set_color_mode(color_mode, sn);
-            }
-        }
+        _set_color_mode(color_mode, _skeleton);
     }
 
     void Robot::set_color_mode(dart::dynamics::MeshShape::ColorMode color_mode, const std::string& body_name)
@@ -401,6 +393,8 @@ namespace robot_dart {
             tmp_skel->getJoint(i)->setPositionLimitEnforced(true);
         }
 
+        _set_color_mode(dart::dynamics::MeshShape::ColorMode::SHAPE_COLOR, tmp_skel);
+
         return tmp_skel;
     }
 
@@ -416,6 +410,17 @@ namespace robot_dart {
             }
             else if (dmg.type == "free_joint") {
                 _skeleton->getJoint(dmg.data)->setActuatorType(dart::dynamics::Joint::PASSIVE);
+            }
+        }
+    }
+
+    void Robot::_set_color_mode(dart::dynamics::MeshShape::ColorMode color_mode, dart::dynamics::SkeletonPtr skel)
+    {
+        for (size_t i = 0; i < skel->getNumBodyNodes(); ++i) {
+            dart::dynamics::BodyNode* bn = skel->getBodyNode(i);
+            for (size_t j = 0; j < bn->getNumShapeNodes(); ++j) {
+                dart::dynamics::ShapeNode* sn = bn->getShapeNode(j);
+                _set_color_mode(color_mode, sn);
             }
         }
     }

--- a/src/robot_dart/robot.cpp
+++ b/src/robot_dart/robot.cpp
@@ -377,20 +377,28 @@ namespace robot_dart {
             tmp_skel->getJoint(i)->setPositionLimitEnforced(true);
         }
 
-        // Fix for mesh materials
-        for (size_t i = 0; i < tmp_skel->getNumBodyNodes(); ++i) {
-            dart::dynamics::BodyNode* bn = tmp_skel->getBodyNode(i);
-            for (size_t j = 0; j < bn->getNumShapeNodes(); ++j) {
-                dart::dynamics::ShapeNode* sn = bn->getShapeNode(j);
-                if (sn->getVisualAspect()) {
-                    dart::dynamics::MeshShape* ms = dynamic_cast<dart::dynamics::MeshShape*>(sn->getShape().get());
-                    if (ms)
-                        ms->setColorMode(dart::dynamics::MeshShape::MATERIAL_COLOR);
-                }
-            }
-        }
 
         return tmp_skel;
+    }
+
+    void Robot::set_color_mode(dart::dynamics::MeshShape::ColorMode color_mode)
+    {
+        for (size_t i = 0; i < _skeleton->getNumBodyNodes(); ++i) {
+	    dart::dynamics::BodyNode* bn = _skeleton->getBodyNode(i);
+	    for (size_t j = 0; j < bn->getNumShapeNodes(); ++j) {
+	        dart::dynamics::ShapeNode* sn = bn->getShapeNode(j);
+		set_color_mode(color_mode, sn);
+	    }
+	}
+    }
+  
+    void Robot::set_color_mode(dart::dynamics::MeshShape::ColorMode color_mode, dart::dynamics::ShapeNode* sn)
+    {
+        if (sn->getVisualAspect()) {
+	    dart::dynamics::MeshShape* ms = dynamic_cast<dart::dynamics::MeshShape*>(sn->getShape().get());
+	    if (ms)
+	        ms->setColorMode(color_mode);
+	}
     }
 
     void Robot::_set_damages(const std::vector<RobotDamage>& damages)

--- a/src/robot_dart/robot.cpp
+++ b/src/robot_dart/robot.cpp
@@ -385,7 +385,7 @@ namespace robot_dart {
                 if (sn->getVisualAspect()) {
                     dart::dynamics::MeshShape* ms = dynamic_cast<dart::dynamics::MeshShape*>(sn->getShape().get());
                     if (ms)
-                        ms->setColorMode(dart::dynamics::MeshShape::SHAPE_COLOR);
+                        ms->setColorMode(dart::dynamics::MeshShape::MATERIAL_COLOR);
                 }
             }
         }

--- a/src/robot_dart/robot.hpp
+++ b/src/robot_dart/robot.hpp
@@ -4,6 +4,7 @@
 #include <utility>
 
 #include <dart/dynamics/Skeleton.hpp>
+#include <dart/dynamics/MeshShape.hpp>
 
 namespace robot_dart {
     namespace control {
@@ -89,7 +90,10 @@ namespace robot_dart {
     protected:
         dart::dynamics::SkeletonPtr _load_model(const std::string& filename, const std::vector<std::pair<std::string, std::string>>& packages = std::vector<std::pair<std::string, std::string>>(), bool is_urdf_string = false);
 
-        void _set_damages(const std::vector<RobotDamage>& damages);
+        void set_color_mode(dart::dynamics::MeshShape::ColorMode color_mode);
+        void set_color_mode(dart::dynamics::MeshShape::ColorMode color_mode, dart::dynamics::ShapeNode* sn);
+
+	void _set_damages(const std::vector<RobotDamage>& damages);
 
         std::string _robot_name;
         dart::dynamics::SkeletonPtr _skeleton;

--- a/src/robot_dart/robot.hpp
+++ b/src/robot_dart/robot.hpp
@@ -94,6 +94,7 @@ namespace robot_dart {
         dart::dynamics::SkeletonPtr _load_model(const std::string& filename, const std::vector<std::pair<std::string, std::string>>& packages = std::vector<std::pair<std::string, std::string>>(), bool is_urdf_string = false);
 
         void _set_damages(const std::vector<RobotDamage>& damages);
+        void _set_color_mode(dart::dynamics::MeshShape::ColorMode color_mode, dart::dynamics::SkeletonPtr skel);
         void _set_color_mode(dart::dynamics::MeshShape::ColorMode color_mode, dart::dynamics::ShapeNode* sn);
 
         std::string _robot_name;

--- a/src/robot_dart/robot.hpp
+++ b/src/robot_dart/robot.hpp
@@ -3,8 +3,8 @@
 
 #include <utility>
 
-#include <dart/dynamics/Skeleton.hpp>
 #include <dart/dynamics/MeshShape.hpp>
+#include <dart/dynamics/Skeleton.hpp>
 
 namespace robot_dart {
     namespace control {
@@ -82,7 +82,7 @@ namespace robot_dart {
         Eigen::Isometry3d body_trans(const std::string& body_name) const;
 
         void set_color_mode(dart::dynamics::MeshShape::ColorMode color_mode);
-        void set_color_mode(dart::dynamics::MeshShape::ColorMode color_mode, dart::dynamics::ShapeNode* sn);
+        void set_color_mode(dart::dynamics::MeshShape::ColorMode color_mode, const std::string& body_name);
 
         // helper functions
         // pose: Orientation-Position
@@ -93,7 +93,8 @@ namespace robot_dart {
     protected:
         dart::dynamics::SkeletonPtr _load_model(const std::string& filename, const std::vector<std::pair<std::string, std::string>>& packages = std::vector<std::pair<std::string, std::string>>(), bool is_urdf_string = false);
 
-	void _set_damages(const std::vector<RobotDamage>& damages);
+        void _set_damages(const std::vector<RobotDamage>& damages);
+        void _set_color_mode(dart::dynamics::MeshShape::ColorMode color_mode, dart::dynamics::ShapeNode* sn);
 
         std::string _robot_name;
         dart::dynamics::SkeletonPtr _skeleton;

--- a/src/robot_dart/robot.hpp
+++ b/src/robot_dart/robot.hpp
@@ -81,6 +81,9 @@ namespace robot_dart {
         Eigen::Matrix3d body_rot(const std::string& body_name) const;
         Eigen::Isometry3d body_trans(const std::string& body_name) const;
 
+        void set_color_mode(dart::dynamics::MeshShape::ColorMode color_mode);
+        void set_color_mode(dart::dynamics::MeshShape::ColorMode color_mode, dart::dynamics::ShapeNode* sn);
+
         // helper functions
         // pose: Orientation-Position
         static std::shared_ptr<Robot> create_box(const Eigen::Vector3d& dims, const Eigen::Vector6d& pose = Eigen::Vector6d::Zero(), const std::string& type = "free", double mass = 1.0, const Eigen::Vector4d& color = dart::Color::Red(1.0), const std::string& box_name = "box");
@@ -89,9 +92,6 @@ namespace robot_dart {
 
     protected:
         dart::dynamics::SkeletonPtr _load_model(const std::string& filename, const std::vector<std::pair<std::string, std::string>>& packages = std::vector<std::pair<std::string, std::string>>(), bool is_urdf_string = false);
-
-        void set_color_mode(dart::dynamics::MeshShape::ColorMode color_mode);
-        void set_color_mode(dart::dynamics::MeshShape::ColorMode color_mode, dart::dynamics::ShapeNode* sn);
 
 	void _set_damages(const std::vector<RobotDamage>& damages);
 


### PR DESCRIPTION
Hi again @costashatz, 

Another very small pull request. We are using a new urdf with meshes and we noticed that the color (defined in the dae file) was not displayed in our visualisations. Changing `SHAPE_COLOR` to `MATERIAL_COLOR` solved our issues, without changing the colors of all the examples in robot_dart. 

Can this small changed be merged to master?

Best, 