### PR TITLE
Added set_base_pose function

### DIFF
--- a/src/robot_dart/robot.cpp
+++ b/src/robot_dart/robot.cpp
@@ -294,6 +294,12 @@ namespace robot_dart {
         return damps;
     }
 
+    void Robot::set_base_pose(const Eigen::Isometry3d& tf)
+    {
+        // Set the pose of the robot base. 
+        _skeleton->getRootBodyNode()->getParentJoint()->setTransformFromParentBodyNode(tf);
+    }
+
     Eigen::Vector3d Robot::body_pos(const std::string& body_name) const
     {
         auto bd = _skeleton->getBodyNode(body_name);

--- a/src/robot_dart/robot.hpp
+++ b/src/robot_dart/robot.hpp
@@ -76,6 +76,8 @@ namespace robot_dart {
         double damping_coeff(size_t dof) const;
         std::vector<double> damping_coeffs() const;
 
+        void set_base_pose(const Eigen::Isometry3d& tf);
+
         Eigen::Vector3d body_pos(const std::string& body_name) const;
         Eigen::Matrix3d body_rot(const std::string& body_name) const;
         Eigen::Isometry3d body_trans(const std::string& body_name) const;


### PR DESCRIPTION
_set_base_pose_ transforms the pose of a robot's base. 

It expects a transformation of type Eigen::Isometry3d as input. 