### PR TITLE
Replace Sdl2Application with GlfwApplication

### DIFF
--- a/docs/cameras.md
+++ b/docs/cameras.md
@@ -1,7 +1,5 @@
-## Using OSG cameras without a X11 server
+## Using OpenGL without a X11 server
 
-When running experiments on a remote computer, for instance via ssh, a X11 server might not be available, which might cause problems while using the Cameras to record images from the simulations (using the OSG graphics). To avoid this you can create a dummy X11 server with:
+When running experiments on a remote computer, for instance via ssh or a cluster environment, a X11 server might not be available, which will cause problems when using any OpenGL call (e.g., WindowlessGLApplication). To avoid this you can create a dummy X11 server with:
 `xinit -- :0 -nolisten tcp vt$XDG_VTNR -noreset +extension GLX +extension RANDR +extension RENDER +extension XFIXES &`
 Then, you can start your application as usual.
-
-

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,7 +33,7 @@ brew install boost
 
 Of course in order to use robot\_dart, you need to install [DART](http://dartsim.github.io/) (from source).
 
-For **Ubuntu systems**, please follow the detailed installation instructions on the [DART documentation website](http://dartsim.github.io/install_dart_on_ubuntu.html#install-required-dependencies). Make sure that you don't forget to add the PPAs as detailed [here](http://dartsim.github.io/install_dart_on_ubuntu.html#adding-personal-package-archives-ppas-for-dart-and-dependencies). What is more, you need to enable the `-DART_ENABLE_SIMD` flag in the CMake configuration. In addition, you need the following optional dependency: **DART Parsers**. Lastly, it is recommended to use either the `master` or `release-6.7` branch (and not the one provided in DART's documentation). In short you should do the following:
+For **Ubuntu systems**, please follow the detailed installation instructions on the [DART documentation website](http://dartsim.github.io/install_dart_on_ubuntu.html#install-required-dependencies). Make sure that you don't forget to add the PPAs as detailed [here](http://dartsim.github.io/install_dart_on_ubuntu.html#adding-personal-package-archives-ppas-for-dart-and-dependencies). What is more, you need to enable the `-DART_ENABLE_SIMD` flag in the CMake configuration. In addition, you need the following optional dependency: **DART Parsers**. Lastly, it is recommended to use either the `master` or `release-6.9` branch (and not the one provided in DART's documentation). In short you should do the following:
 
 **Ubuntu <= 14.04 only**
 
@@ -57,7 +57,7 @@ sudo apt-get install liburdfdom-dev liburdfdom-headers-dev
 cd /path/to/tmp/folder
 git clone git://github.com/dartsim/dart.git
 cd dart
-git checkout release-6.7
+git checkout release-6.9
 
 mkdir build
 cd build
@@ -84,7 +84,7 @@ brew install urdfdom
 cd /path/to/tmp/folder
 git clone git://github.com/dartsim/dart.git
 cd dart
-git checkout release-6.7
+git checkout release-6.9
 
 mkdir build
 cd build
@@ -95,14 +95,14 @@ sudo make install
 
 #### Installing Magnum
 
-Magnum depends on [Corrade](https://github.com/mosra/corrade) and we are going to use a few plugins and extras from the library. We are also going to use SDL2 for the back-end. Follow the instrutions below:
+Magnum depends on [Corrade](https://github.com/mosra/corrade) and we are going to use a few plugins and extras from the library. We are also going to use Glfw and Glx for the back-end. Follow the instrutions below:
 
 ```bash
-#installation of SDL2
+#installation of Glfw
 # Ubuntu
-sudo apt-get install libsdl2-dev
+sudo apt-get install libglfw3-dev libglfw3
 # Mac OSX
-brew install sdl2
+brew install glfw3
 
 # installation of Corrade
 cd /path/to/tmp/folder
@@ -119,9 +119,9 @@ git clone https://github.com/mosra/magnum.git
 cd magnum
 mkdir build && cd build
 # Ubuntu
-cmake -DWITH_AUDIO=ON -DWITH_DEBUGTOOLS=ON -DWITH_GL=ON -DWITH_MESHTOOLS=ON -DWITH_PRIMITIVES=ON -DWITH_SCENEGRAPH=ON -DWITH_SHADERS=ON -DWITH_TEXT=ON -DWITH_TEXTURETOOLS=ON -DWITH_TRADE=ON -DWITH_SDL2APPLICATION=ON -DWITH_WINDOWLESSGLXAPPLICATION=ON -DWITH_OPENGLTESTER=ON -DWITH_ANYAUDIOIMPORTER=ON -DWITH_ANYIMAGECONVERTER=ON -DWITH_ANYIMAGEIMPORTER=ON -DWITH_ANYSCENEIMPORTER=ON -DWITH_MAGNUMFONT=ON -DWITH_OBJIMPORTER=ON -DWITH_TGAIMPORTER=ON -DWITH_WAVAUDIOIMPORTER=ON .. # this will enable almost all features of Magnum that are not necessarily needed for robot_dart (please refer to the documentation of Magnum for more details on selecting only the ones that you need)
+cmake -DWITH_AUDIO=ON -DWITH_DEBUGTOOLS=ON -DWITH_GL=ON -DWITH_MESHTOOLS=ON -DWITH_PRIMITIVES=ON -DWITH_SCENEGRAPH=ON -DWITH_SHADERS=ON -DWITH_TEXT=ON -DWITH_TEXTURETOOLS=ON -DWITH_TRADE=ON -DWITH_GLFWAPPLICATION=ON -DWITH_WINDOWLESSGLXAPPLICATION=ON -DWITH_OPENGLTESTER=ON -DWITH_ANYAUDIOIMPORTER=ON -DWITH_ANYIMAGECONVERTER=ON -DWITH_ANYIMAGEIMPORTER=ON -DWITH_ANYSCENEIMPORTER=ON -DWITH_MAGNUMFONT=ON -DWITH_OBJIMPORTER=ON -DWITH_TGAIMPORTER=ON -DWITH_WAVAUDIOIMPORTER=ON .. # this will enable almost all features of Magnum that are not necessarily needed for robot_dart (please refer to the documentation of Magnum for more details on selecting only the ones that you need)
 # Mac OSX
-cmake -DWITH_AUDIO=ON -DWITH_DEBUGTOOLS=ON -DWITH_GL=ON -DWITH_MESHTOOLS=ON -DWITH_PRIMITIVES=ON -DWITH_SCENEGRAPH=ON -DWITH_SHADERS=ON -DWITH_TEXT=ON -DWITH_TEXTURETOOLS=ON -DWITH_TRADE=ON -DWITH_SDL2APPLICATION=ON -DWITH_WINDOWLESSCGLAPPLICATION=ON -DWITH_OPENGLTESTER=ON -DWITH_ANYAUDIOIMPORTER=ON -DWITH_ANYIMAGECONVERTER=ON -DWITH_ANYIMAGEIMPORTER=ON -DWITH_ANYSCENEIMPORTER=ON -DWITH_MAGNUMFONT=ON -DWITH_OBJIMPORTER=ON -DWITH_TGAIMPORTER=ON -DWITH_WAVAUDIOIMPORTER=ON .. # this will enable almost all features of Magnum that are not necessarily needed for robot_dart (please refer to the documentation of Magnum for more details on selecting only the ones that you need)
+cmake -DWITH_AUDIO=ON -DWITH_DEBUGTOOLS=ON -DWITH_GL=ON -DWITH_MESHTOOLS=ON -DWITH_PRIMITIVES=ON -DWITH_SCENEGRAPH=ON -DWITH_SHADERS=ON -DWITH_TEXT=ON -DWITH_TEXTURETOOLS=ON -DWITH_TRADE=ON -DWITH_GLFWAPPLICATION=ON -DWITH_WINDOWLESSCGLAPPLICATION=ON -DWITH_OPENGLTESTER=ON -DWITH_ANYAUDIOIMPORTER=ON -DWITH_ANYIMAGECONVERTER=ON -DWITH_ANYIMAGEIMPORTER=ON -DWITH_ANYSCENEIMPORTER=ON -DWITH_MAGNUMFONT=ON -DWITH_OBJIMPORTER=ON -DWITH_TGAIMPORTER=ON -DWITH_WAVAUDIOIMPORTER=ON .. # this will enable almost all features of Magnum that are not necessarily needed for robot_dart (please refer to the documentation of Magnum for more details on selecting only the ones that you need)
 make -j
 sudo make install
 

--- a/src/examples/cameras.cpp
+++ b/src/examples/cameras.cpp
@@ -6,18 +6,19 @@
 #include <robot_dart/gui/magnum/camera_osr.hpp>
 #include <robot_dart/gui/magnum/graphics.hpp>
 
-class MyApp : public robot_dart::gui::magnum::Sdl2Application {
+class MyApp : public robot_dart::gui::magnum::GlfwApplication {
 public:
-    explicit MyApp(int argc, char** argv, const dart::simulation::WorldPtr& world, size_t width, size_t height, const std::string& title = "DART", bool shadowed = true) : Sdl2Application(argc, argv, world, width, height, title, shadowed) {}
+    explicit MyApp(int argc, char** argv, const dart::simulation::WorldPtr& world, size_t width, size_t height, const std::string& title = "DART", bool shadowed = true)
+        : GlfwApplication(argc, argv, world, width, height, title, shadowed) {}
 
 protected:
     void keyPressEvent(KeyEvent& event) override
     {
-        // One can customize their key/mouse events by inheriting Sdl2Application
+        // One can customize their key/mouse events by inheriting GlfwApplication
         // if (event.key() == KeyEvent::Key::Right) {
         // }
 
-        robot_dart::gui::magnum::Sdl2Application::keyPressEvent(event);
+        robot_dart::gui::magnum::GlfwApplication::keyPressEvent(event);
     }
 };
 

--- a/src/robot_dart/gui/magnum/glfw_application.cpp
+++ b/src/robot_dart/gui/magnum/glfw_application.cpp
@@ -1,4 +1,4 @@
-#include "sdl2_application.hpp"
+#include "glfw_application.hpp"
 
 #include <Magnum/GL/DefaultFramebuffer.h>
 #include <Magnum/GL/Renderer.h>
@@ -8,7 +8,7 @@
 namespace robot_dart {
     namespace gui {
         namespace magnum {
-            Sdl2Application::Sdl2Application(int argc, char** argv, const dart::simulation::WorldPtr& world, size_t width, size_t height, const std::string& title, bool isShadowed)
+            GlfwApplication::GlfwApplication(int argc, char** argv, const dart::simulation::WorldPtr& world, size_t width, size_t height, const std::string& title, bool isShadowed)
                 : BaseApplication(isShadowed), Magnum::Platform::Application({argc, argv}, Magnum::NoCreate), _speedMove(0.f), _speedStrafe(0.f)
             {
                 /* Try 16x MSAA */
@@ -26,29 +26,28 @@ namespace robot_dart {
 
                 /* Loop at 60 Hz max */
                 setSwapInterval(1);
-                setMinimalLoopPeriod(16);
 
                 redraw();
             }
 
-            Sdl2Application::~Sdl2Application()
+            GlfwApplication::~GlfwApplication()
             {
                 GLCleanUp();
             }
 
-            void Sdl2Application::render()
+            void GlfwApplication::render()
             {
                 mainLoopIteration();
             }
 
-            void Sdl2Application::viewportEvent(const Magnum::Vector2i& size)
+            void GlfwApplication::viewportEvent(const Magnum::Vector2i& size)
             {
                 Magnum::GL::defaultFramebuffer.setViewport({{}, size});
 
                 _camera->setViewport(size);
             }
 
-            void Sdl2Application::drawEvent()
+            void GlfwApplication::drawEvent()
             {
                 /* Update graphic meshes/materials and render */
                 updateGraphics();
@@ -76,7 +75,7 @@ namespace robot_dart {
                 redraw();
             }
 
-            void Sdl2Application::keyReleaseEvent(KeyEvent& event)
+            void GlfwApplication::keyReleaseEvent(KeyEvent& event)
             {
                 _speedMove = 0.f;
                 _speedStrafe = 0.f;
@@ -84,7 +83,7 @@ namespace robot_dart {
                 event.setAccepted();
             }
 
-            void Sdl2Application::keyPressEvent(KeyEvent& event)
+            void GlfwApplication::keyPressEvent(KeyEvent& event)
             {
                 if (event.key() == KeyEvent::Key::W) {
                     _speedMove = _speed;
@@ -105,7 +104,7 @@ namespace robot_dart {
                 event.setAccepted();
             }
 
-            void Sdl2Application::mouseScrollEvent(MouseScrollEvent& event)
+            void GlfwApplication::mouseScrollEvent(MouseScrollEvent& event)
             {
                 if (!event.offset().y())
                     return;
@@ -121,7 +120,7 @@ namespace robot_dart {
                 event.setAccepted();
             }
 
-            void Sdl2Application::mouseMoveEvent(MouseMoveEvent& event)
+            void GlfwApplication::mouseMoveEvent(MouseMoveEvent& event)
             {
                 if (event.buttons() == MouseMoveEvent::Button::Left) {
                     _camera->move(event.relativePosition());
@@ -130,7 +129,7 @@ namespace robot_dart {
                 event.setAccepted();
             }
 
-            void Sdl2Application::exitEvent(ExitEvent& event)
+            void GlfwApplication::exitEvent(ExitEvent& event)
             {
                 _done = true;
                 event.setAccepted();

--- a/src/robot_dart/gui/magnum/glfw_application.hpp
+++ b/src/robot_dart/gui/magnum/glfw_application.hpp
@@ -1,18 +1,24 @@
-#ifndef ROBOT_DART_GUI_MAGNUM_SDL2_APPLICATION_HPP
-#define ROBOT_DART_GUI_MAGNUM_SDL2_APPLICATION_HPP
+#ifndef ROBOT_DART_GUI_MAGNUM_GLFW_APPLICATION_HPP
+#define ROBOT_DART_GUI_MAGNUM_GLFW_APPLICATION_HPP
 
 #include <robot_dart/gui/magnum/base_application.hpp>
 
-#include <Magnum/Platform/Sdl2Application.h>
+// Workaround for X11lib defines
+#undef Button1
+#undef Button2
+#undef Button3
+#undef Button4
+#undef Button5
+#include <Magnum/Platform/GlfwApplication.h>
 
 namespace robot_dart {
     namespace gui {
         namespace magnum {
-            class Sdl2Application : public BaseApplication, public Magnum::Platform::Application {
+            class GlfwApplication : public BaseApplication, public Magnum::Platform::Application {
             public:
-                explicit Sdl2Application(int argc, char** argv, const dart::simulation::WorldPtr& world, size_t width, size_t height, const std::string& title = "DART", bool isShadowed = true);
+                explicit GlfwApplication(int argc, char** argv, const dart::simulation::WorldPtr& world, size_t width, size_t height, const std::string& title = "DART", bool isShadowed = true);
 
-                ~Sdl2Application();
+                ~GlfwApplication();
 
                 void render() override;
 

--- a/src/robot_dart/gui/magnum/graphics.hpp
+++ b/src/robot_dart/gui/magnum/graphics.hpp
@@ -2,8 +2,8 @@
 #define ROBOT_DART_GUI_MAGNUM_GRAPHICS_HPP
 
 #include <robot_dart/gui/base.hpp>
+#include <robot_dart/gui/magnum/glfw_application.hpp>
 #include <robot_dart/gui/magnum/gs/helper.hpp>
-#include <robot_dart/gui/magnum/sdl2_application.hpp>
 
 // We need this for CORRADE_RESOURCE_INITIALIZE
 #include <Corrade/Utility/Resource.h>
@@ -16,7 +16,7 @@ static void robot_dart_initialize_magnum_resources()
 namespace robot_dart {
     namespace gui {
         namespace magnum {
-            template <typename T = Sdl2Application>
+            template <typename T = GlfwApplication>
             class Graphics : public Base {
             public:
                 Graphics(const dart::simulation::WorldPtr& world, unsigned int width = 640, unsigned int height = 480, bool shadowed = true, const std::string& title = "DART")

--- a/waf_tools/magnum.py
+++ b/waf_tools/magnum.py
@@ -279,7 +279,7 @@ def check_magnum(conf, *k, **kw):
                         magnum_component_includes[component] = magnum_component_includes[component] + [glfw_inc]
 
                         # conf.start_msg('Magnum: Checking for GLFW3 lib')
-                        libs_glfw = ['glfw', 'glfw3']
+                        libs_glfw = ['glfw3', 'glfw']
                         glfw_found = False
                         for lib_glfw in libs_glfw:
                             try:
@@ -365,11 +365,11 @@ def check_magnum(conf, *k, **kw):
                         if not egl_found:
                             fatal(required, 'Not found')
                             return
-                    elif component == 'WindowlessGlxApplication':
-                        # WindowlessGlxApplication requires GLX. X11
-                        egl_inc = get_directory('GL/glx.h', includes_check)
+                    elif component == 'WindowlessGlxApplication' or component == 'GlxApplication':
+                        # [Windowless]GlxApplication requires GLX. X11
+                        glx_inc = get_directory('GL/glx.h', includes_check)
 
-                        magnum_component_includes[component] = magnum_component_includes[component] + [egl_inc]
+                        magnum_component_includes[component] = magnum_component_includes[component] + [glx_inc]
 
                         libs_glx = ['GLX', 'X11']
                         glx_found = False

--- a/wscript
+++ b/wscript
@@ -62,7 +62,7 @@ def configure(conf):
     conf.check_dart(required=True)
     conf.check_hexapod_controller()
     conf.check_corrade(components='Utility PluginManager', required=False)
-    conf.env['magnum_dep_libs'] = 'MeshTools Primitives Shaders SceneGraph Sdl2Application'
+    conf.env['magnum_dep_libs'] = 'MeshTools Primitives Shaders SceneGraph GlfwApplication'
     if conf.env['DEST_OS'] == 'darwin':
         conf.env['magnum_dep_libs'] += ' WindowlessCglApplication'
     else:


### PR DESCRIPTION
Sdl2Application has some troubles running on headless cluster environments. For this reason, we replace with the GlfwApplication which seems to be running better. This needs https://github.com/mosra/magnum/pull/387, https://github.com/mosra/magnum/pull/388 and https://github.com/mosra/magnum/pull/389 to be merged first..