### PR TITLE
Robust magnum detection

### DIFF
--- a/waf_tools/corrade.py
+++ b/waf_tools/corrade.py
@@ -7,6 +7,7 @@ Quick n dirty Corrade detection
 """
 
 import os
+import io
 from waflib import Utils, Logs
 from waflib.Configure import conf
 import copy
@@ -112,7 +113,7 @@ def check_corrade(conf, *k, **kw):
 
         conf.start_msg('Getting Corrade configuration')
         config_file = conf.find_file('Corrade/configure.h', includes_check)
-        with open(config_file) as f:
+        with io.open(config_file, errors = 'ignore') as f:
             config_content = f.read()
         for config in corrade_possible_configs:
             index = find_in_string(config_content, '#define CORRADE_' + config)
@@ -263,7 +264,7 @@ class readFile(Task):
         config_file = self.inputs[0]
         config_file_path = config_file.abspath()[:config_file.abspath().rfind('/')]
         try:
-            with open(config_file.abspath()) as f:
+            with io.open(config_file.abspath(), errors = 'ignore') as f:
                 config_content = f.readlines()
         except:
             self.fatal('Could not load file \'' + config_file.abspath() + '\'')

--- a/waf_tools/corrade.py
+++ b/waf_tools/corrade.py
@@ -280,7 +280,7 @@ class readFile(Task):
                 filename = results.group(1).strip()
                 if filename[0] != '/':
                     filename = config_file_path + '/' + filename
-                filename = filename.encode('ascii','ignore')
+                filename = str(filename)
                 dependencies.append(self.generator.bld.root.find_node(filename))
         return (dependencies, time.time())
 

--- a/waf_tools/corrade.py
+++ b/waf_tools/corrade.py
@@ -280,6 +280,7 @@ class readFile(Task):
                 filename = results.group(1).strip()
                 if filename[0] != '/':
                     filename = config_file_path + '/' + filename
+                filename = filename.encode('ascii','ignore')
                 dependencies.append(self.generator.bld.root.find_node(filename))
         return (dependencies, time.time())
 

--- a/waf_tools/magnum.py
+++ b/waf_tools/magnum.py
@@ -7,6 +7,7 @@ Quick n dirty Magnum detection
 """
 
 import os
+import io
 import re
 from waflib import Utils, Logs
 from waflib.Configure import conf
@@ -183,7 +184,7 @@ def check_magnum(conf, *k, **kw):
 
         conf.start_msg('Getting Magnum configuration')
         config_file = conf.find_file('Magnum/configure.h', includes_check)
-        with open(config_file) as f:
+        with io.open(config_file, errors = 'ignore') as f:
             config_content = f.read()
         for config in magnum_possible_configs:
             index = find_in_string(config_content, '#define MAGNUM_' + config)


### PR DESCRIPTION
Hi, 

I have a small, yet annoying, issue when trying to compile robot_dart with python3 (i.e., without python2 on my system). The issue is when we look for the config files of magnum and corrade, which have an encoding that seems to be causing problem, in python3, not python2.

Here is a small PR that fix it. I have tested it on OSX, Ubuntu, with Python2 and Python3. 