### PR TITLE
Actuator Types

### DIFF
--- a/cmake/example/example.cpp
+++ b/cmake/example/example.cpp
@@ -31,7 +31,7 @@ int main()
     // g_robot->skeleton()->setPosition(1, M_PI / 2.0);
     Eigen::Vector3d size(0, 0, 0);
 
-    global_robot->set_actuator_types(dart::dynamics::Joint::VELOCITY);
+    global_robot->set_actuator_types("velocity");
 
     Eigen::VectorXd ctrl(4);
     ctrl << 0.0, 1.0, -1.5, 1.0;

--- a/src/examples/arm.cpp
+++ b/src/examples/arm.cpp
@@ -31,7 +31,7 @@ int main()
     // g_robot->skeleton()->setPosition(1, M_PI / 2.0);
     Eigen::Vector3d size(0, 0, 0);
 
-    global_robot->set_actuator_type("velocity");
+    global_robot->set_actuator_types("velocity");
 
     Eigen::VectorXd ctrl(4);
     ctrl << 0.0, 1.0, -1.5, 1.0;

--- a/src/examples/arm.cpp
+++ b/src/examples/arm.cpp
@@ -31,7 +31,7 @@ int main()
     // g_robot->skeleton()->setPosition(1, M_PI / 2.0);
     Eigen::Vector3d size(0, 0, 0);
 
-    global_robot->set_actuator_types(dart::dynamics::Joint::VELOCITY);
+    global_robot->set_actuator_type("velocity");
 
     Eigen::VectorXd ctrl(4);
     ctrl << 0.0, 1.0, -1.5, 1.0;

--- a/src/examples/dof_maps.cpp
+++ b/src/examples/dof_maps.cpp
@@ -20,7 +20,7 @@ int main()
     global_robot->set_position_enforced(true);
 
     // Set actuator types to SERVO motors so that they stay in position without any controller
-    global_robot->set_actuator_type("servo");
+    global_robot->set_actuator_types("servo");
 
     float dt = 0.001;
     robot_dart::RobotDARTSimu simu(dt);
@@ -76,8 +76,8 @@ int main()
     bool filter_mimics = true, filter_locked = true, filter_passive = true;
 
     global_robot->set_mimic("iiwa_joint_5", "iiwa_joint_1");
-    global_robot->set_actuator_type("locked", {"iiwa_joint_6"});
-    global_robot->set_actuator_type("passive", {"iiwa_joint_7"});
+    global_robot->set_actuator_type("locked", "iiwa_joint_6");
+    global_robot->set_actuator_type("passive", "iiwa_joint_7");
 
     //Get the controllable joints (You cannot send a command to a mimic or passive or locked joint)
     auto controllable_dofs = global_robot->dof_names(filter_mimics, filter_locked, filter_passive);

--- a/src/examples/dof_maps.cpp
+++ b/src/examples/dof_maps.cpp
@@ -20,7 +20,7 @@ int main()
     global_robot->set_position_enforced(true);
 
     // Set actuator types to SERVO motors so that they stay in position without any controller
-    global_robot->set_actuator_types(dart::dynamics::Joint::SERVO);
+    global_robot->set_actuator_type("servo");
 
     float dt = 0.001;
     robot_dart::RobotDARTSimu simu(dt);
@@ -73,16 +73,11 @@ int main()
     // }
 
     /**************** Mimic / Passive / Locked joint handling ********************************************************/
-
-    int mimic_index = global_robot->dof_index("iiwa_joint_5");
-    int locked_index = global_robot->dof_index("iiwa_joint_6");
-    int passive_index = global_robot->dof_index("iiwa_joint_7");
-
     bool filter_mimics = true, filter_locked = true, filter_passive = true;
 
-    global_robot->set_actuator_type(mimic_index, dart::dynamics::Joint::MIMIC, true);
-    global_robot->set_actuator_type(locked_index, dart::dynamics::Joint::LOCKED, true);
-    global_robot->set_actuator_type(passive_index, dart::dynamics::Joint::PASSIVE, true);
+    global_robot->set_mimic("iiwa_joint_5", "iiwa_joint_1");
+    global_robot->set_actuator_type("locked", {"iiwa_joint_6"});
+    global_robot->set_actuator_type("passive", {"iiwa_joint_7"});
 
     //Get the controllable joints (You cannot send a command to a mimic or passive or locked joint)
     auto controllable_dofs = global_robot->dof_names(filter_mimics, filter_locked, filter_passive);

--- a/src/examples/hexapod.cpp
+++ b/src/examples/hexapod.cpp
@@ -12,7 +12,7 @@ int main()
 
     global_robot->set_position_enforced(true);
 
-    global_robot->set_actuator_type("servo");
+    global_robot->set_actuator_types("servo");
     global_robot->skeleton()->enableSelfCollisionCheck();
 
     auto g_robot = global_robot->clone();

--- a/src/examples/hexapod.cpp
+++ b/src/examples/hexapod.cpp
@@ -12,7 +12,7 @@ int main()
 
     global_robot->set_position_enforced(true);
 
-    global_robot->set_actuator_types(dart::dynamics::Joint::SERVO);
+    global_robot->set_actuator_type("servo");
     global_robot->skeleton()->enableSelfCollisionCheck();
 
     auto g_robot = global_robot->clone();

--- a/src/python/robot.cpp
+++ b/src/python/robot.cpp
@@ -46,9 +46,15 @@ namespace robot_dart {
                 .def("fixed", &Robot::fixed)
                 .def("free", &Robot::free)
 
-                .def("set_actuator_type", &Robot::set_actuator_type,
+                .def("set_actuator_types", &Robot::set_actuator_types,
                     py::arg("type"),
                     py::arg("joint_names") = std::vector<std::string>(),
+                    py::arg("override_mimic") = false,
+                    py::arg("override_base") = false)
+
+                .def("set_actuator_type", &Robot::set_actuator_type,
+                    py::arg("type"),
+                    py::arg("joint_name"),
                     py::arg("override_mimic") = false,
                     py::arg("override_base") = false)
 

--- a/src/python/robot.cpp
+++ b/src/python/robot.cpp
@@ -63,6 +63,23 @@ namespace robot_dart {
                 .def("actuator_type", &Robot::actuator_type)
                 .def("actuator_types", &Robot::actuator_types)
 
+                .def("set_control_mode", &Robot::set_control_mode,
+                    py::arg("mode"),
+                    py::arg("dof_names") = std::vector<std::string>(),
+                    py::arg("override_mimic") = false,
+                    py::arg("override_base") = false)
+
+                .def("set_mimic", &Robot::set_mimic,
+                    py::arg("dof_name"),
+                    py::arg("mimic_dof_name"),
+                    py::arg("multiplier") = 1.,
+                    py::arg("offset") = 0.)
+
+                .def("control_mode", &Robot::control_mode)
+
+                .def("control_modes", &Robot::control_modes,
+                    py::arg("dof_names") = std::vector<std::string>())
+
                 .def("set_position_enforced", (void (Robot::*)(size_t, bool)) & Robot::set_position_enforced)
                 .def("set_position_enforced", (void (Robot::*)(const std::vector<bool>&)) & Robot::set_position_enforced)
                 .def("set_position_enforced", (void (Robot::*)(bool)) & Robot::set_position_enforced)

--- a/src/python/robot.cpp
+++ b/src/python/robot.cpp
@@ -48,20 +48,20 @@ namespace robot_dart {
 
                 .def("set_actuator_type", &Robot::set_actuator_type,
                     py::arg("type"),
-                    py::arg("dof_names") = std::vector<std::string>(),
+                    py::arg("joint_names") = std::vector<std::string>(),
                     py::arg("override_mimic") = false,
                     py::arg("override_base") = false)
 
                 .def("set_mimic", &Robot::set_mimic,
-                    py::arg("dof_name"),
-                    py::arg("mimic_dof_name"),
+                    py::arg("joint_name"),
+                    py::arg("mimic_joint_name"),
                     py::arg("multiplier") = 1.,
                     py::arg("offset") = 0.)
 
                 .def("actuator_type", &Robot::actuator_type)
 
                 .def("actuator_types", &Robot::actuator_types,
-                    py::arg("dof_names") = std::vector<std::string>())
+                    py::arg("joint_names") = std::vector<std::string>())
 
                 .def("set_position_enforced", (void (Robot::*)(size_t, bool)) & Robot::set_position_enforced)
                 .def("set_position_enforced", (void (Robot::*)(const std::vector<bool>&)) & Robot::set_position_enforced)

--- a/src/python/robot.cpp
+++ b/src/python/robot.cpp
@@ -47,24 +47,7 @@ namespace robot_dart {
                 .def("free", &Robot::free)
 
                 .def("set_actuator_type", &Robot::set_actuator_type,
-                    py::arg("index"),
                     py::arg("type"),
-                    py::arg("override_mimic") = false,
-                    py::arg("override_base") = false)
-                .def("set_actuator_types", (void (Robot::*)(const std::vector<dart::dynamics::Joint::ActuatorType>&, bool, bool)) & Robot::set_actuator_types,
-                    py::arg("types"),
-                    py::arg("override_mimic") = false,
-                    py::arg("override_base") = false)
-                .def("set_actuator_types", (void (Robot::*)(dart::dynamics::Joint::ActuatorType, bool, bool)) & Robot::set_actuator_types,
-                    py::arg("types"),
-                    py::arg("override_mimic") = false,
-                    py::arg("override_base") = false)
-
-                .def("actuator_type", &Robot::actuator_type)
-                .def("actuator_types", &Robot::actuator_types)
-
-                .def("set_control_mode", &Robot::set_control_mode,
-                    py::arg("mode"),
                     py::arg("dof_names") = std::vector<std::string>(),
                     py::arg("override_mimic") = false,
                     py::arg("override_base") = false)
@@ -75,9 +58,9 @@ namespace robot_dart {
                     py::arg("multiplier") = 1.,
                     py::arg("offset") = 0.)
 
-                .def("control_mode", &Robot::control_mode)
+                .def("actuator_type", &Robot::actuator_type)
 
-                .def("control_modes", &Robot::control_modes,
+                .def("actuator_types", &Robot::actuator_types,
                     py::arg("dof_names") = std::vector<std::string>())
 
                 .def("set_position_enforced", (void (Robot::*)(size_t, bool)) & Robot::set_position_enforced)

--- a/src/robot_dart/robot.cpp
+++ b/src/robot_dart/robot.cpp
@@ -365,7 +365,7 @@ namespace robot_dart {
         return parent_jt->getType() == dart::dynamics::FreeJoint::getStaticType();
     }
 
-    void Robot::set_actuator_type(const std::string& type, const std::vector<std::string>& joint_names, bool override_mimic, bool override_base)
+    void Robot::set_actuator_types(const std::string& type, const std::vector<std::string>& joint_names, bool override_mimic, bool override_base)
     {
         // Set all dofs to same actuator type
         if (joint_names.empty()) {
@@ -416,6 +416,11 @@ namespace robot_dart {
             else
                 ROBOT_DART_EXCEPTION_ASSERT(false, "Unknown type of actuator type. Valid values: torque, servo, velocity, passive, locked, mimic");
         }
+    }
+
+    void Robot::set_actuator_type(const std::string& type, const std::string& joint_name, bool override_mimic, bool override_base)
+    {
+        set_actuator_types(type, {joint_name}, override_mimic, override_base);
     }
 
     void Robot::set_mimic(const std::string& joint_name, const std::string& mimic_joint_name, double multiplier, double offset)

--- a/src/robot_dart/robot.hpp
+++ b/src/robot_dart/robot.hpp
@@ -64,6 +64,13 @@ namespace robot_dart {
         dart::dynamics::Joint::ActuatorType actuator_type(size_t index) const;
         std::vector<dart::dynamics::Joint::ActuatorType> actuator_types() const;
 
+        // control mode can be: torque, servo, velocity, passive, locked, mimic (only for completeness, use set_mimic to use this)
+        void set_control_mode(const std::string& mode, const std::vector<std::string>& dof_names = {}, bool override_mimic = false, bool override_base = false);
+        void set_mimic(const std::string& dof_name, const std::string& mimic_dof_name, double multiplier = 1., double offset = 0.);
+
+        std::string control_mode(const std::string& dof_name) const;
+        std::vector<std::string> control_modes(const std::vector<std::string>& dof_names = {}) const;
+
         void set_position_enforced(size_t dof, bool enforced);
         void set_position_enforced(const std::vector<bool>& enforced);
         void set_position_enforced(bool enforced);

--- a/src/robot_dart/robot.hpp
+++ b/src/robot_dart/robot.hpp
@@ -57,19 +57,12 @@ namespace robot_dart {
         bool fixed() const;
         bool free() const;
 
-        void set_actuator_type(size_t index, dart::dynamics::Joint::ActuatorType type, bool override_mimic = false, bool override_base = false);
-        void set_actuator_types(const std::vector<dart::dynamics::Joint::ActuatorType>& types, bool override_mimic = false, bool override_base = false);
-        void set_actuator_types(dart::dynamics::Joint::ActuatorType type, bool override_mimic = false, bool override_base = false);
-
-        dart::dynamics::Joint::ActuatorType actuator_type(size_t index) const;
-        std::vector<dart::dynamics::Joint::ActuatorType> actuator_types() const;
-
-        // control mode can be: torque, servo, velocity, passive, locked, mimic (only for completeness, use set_mimic to use this)
-        void set_control_mode(const std::string& mode, const std::vector<std::string>& dof_names = {}, bool override_mimic = false, bool override_base = false);
+        // actuator type can be: torque, servo, velocity, passive, locked, mimic (only for completeness, use set_mimic to use this)
+        void set_actuator_type(const std::string& type, const std::vector<std::string>& dof_names = {}, bool override_mimic = false, bool override_base = false);
         void set_mimic(const std::string& dof_name, const std::string& mimic_dof_name, double multiplier = 1., double offset = 0.);
 
-        std::string control_mode(const std::string& dof_name) const;
-        std::vector<std::string> control_modes(const std::vector<std::string>& dof_names = {}) const;
+        std::string actuator_type(const std::string& dof_name) const;
+        std::vector<std::string> actuator_types(const std::vector<std::string>& dof_names = {}) const;
 
         void set_position_enforced(size_t dof, bool enforced);
         void set_position_enforced(const std::vector<bool>& enforced);
@@ -188,6 +181,13 @@ namespace robot_dart {
         void _set_damages(const std::vector<RobotDamage>& damages);
         void _set_color_mode(dart::dynamics::MeshShape::ColorMode color_mode, dart::dynamics::SkeletonPtr skel);
         void _set_color_mode(dart::dynamics::MeshShape::ColorMode color_mode, dart::dynamics::ShapeNode* sn);
+
+        void _set_actuator_type(size_t index, dart::dynamics::Joint::ActuatorType type, bool override_mimic = false, bool override_base = false);
+        void _set_actuator_types(const std::vector<dart::dynamics::Joint::ActuatorType>& types, bool override_mimic = false, bool override_base = false);
+        void _set_actuator_types(dart::dynamics::Joint::ActuatorType type, bool override_mimic = false, bool override_base = false);
+
+        dart::dynamics::Joint::ActuatorType _actuator_type(size_t index) const;
+        std::vector<dart::dynamics::Joint::ActuatorType> _actuator_types() const;
 
         std::string _robot_name;
         dart::dynamics::SkeletonPtr _skeleton;

--- a/src/robot_dart/robot.hpp
+++ b/src/robot_dart/robot.hpp
@@ -59,7 +59,8 @@ namespace robot_dart {
 
         // actuator type can be: torque, servo, velocity, passive, locked, mimic (only for completeness, use set_mimic to use this)
         // Be careful that actuator types are per joint and not per DoF
-        void set_actuator_type(const std::string& type, const std::vector<std::string>& joint_names = {}, bool override_mimic = false, bool override_base = false);
+        void set_actuator_types(const std::string& type, const std::vector<std::string>& joint_names = {}, bool override_mimic = false, bool override_base = false);
+        void set_actuator_type(const std::string& type, const std::string& joint_name, bool override_mimic = false, bool override_base = false);
         void set_mimic(const std::string& joint_name, const std::string& mimic_joint_name, double multiplier = 1., double offset = 0.);
 
         std::string actuator_type(const std::string& joint_name) const;

--- a/src/robot_dart/robot.hpp
+++ b/src/robot_dart/robot.hpp
@@ -58,11 +58,12 @@ namespace robot_dart {
         bool free() const;
 
         // actuator type can be: torque, servo, velocity, passive, locked, mimic (only for completeness, use set_mimic to use this)
-        void set_actuator_type(const std::string& type, const std::vector<std::string>& dof_names = {}, bool override_mimic = false, bool override_base = false);
-        void set_mimic(const std::string& dof_name, const std::string& mimic_dof_name, double multiplier = 1., double offset = 0.);
+        // Be careful that actuator types are per joint and not per DoF
+        void set_actuator_type(const std::string& type, const std::vector<std::string>& joint_names = {}, bool override_mimic = false, bool override_base = false);
+        void set_mimic(const std::string& joint_name, const std::string& mimic_joint_name, double multiplier = 1., double offset = 0.);
 
-        std::string actuator_type(const std::string& dof_name) const;
-        std::vector<std::string> actuator_types(const std::vector<std::string>& dof_names = {}) const;
+        std::string actuator_type(const std::string& joint_name) const;
+        std::vector<std::string> actuator_types(const std::vector<std::string>& joint_names = {}) const;
 
         void set_position_enforced(size_t dof, bool enforced);
         void set_position_enforced(const std::vector<bool>& enforced);
@@ -182,11 +183,11 @@ namespace robot_dart {
         void _set_color_mode(dart::dynamics::MeshShape::ColorMode color_mode, dart::dynamics::SkeletonPtr skel);
         void _set_color_mode(dart::dynamics::MeshShape::ColorMode color_mode, dart::dynamics::ShapeNode* sn);
 
-        void _set_actuator_type(size_t index, dart::dynamics::Joint::ActuatorType type, bool override_mimic = false, bool override_base = false);
+        void _set_actuator_type(size_t joint_index, dart::dynamics::Joint::ActuatorType type, bool override_mimic = false, bool override_base = false);
         void _set_actuator_types(const std::vector<dart::dynamics::Joint::ActuatorType>& types, bool override_mimic = false, bool override_base = false);
         void _set_actuator_types(dart::dynamics::Joint::ActuatorType type, bool override_mimic = false, bool override_base = false);
 
-        dart::dynamics::Joint::ActuatorType _actuator_type(size_t index) const;
+        dart::dynamics::Joint::ActuatorType _actuator_type(size_t joint_index) const;
         std::vector<dart::dynamics::Joint::ActuatorType> _actuator_types() const;
 
         std::string _robot_name;

--- a/src/tests/test_robot.cpp
+++ b/src/tests/test_robot.cpp
@@ -84,8 +84,8 @@ BOOST_AUTO_TEST_CASE(test_actuators)
     }
 
     // check simple dof setting
-    pexod->set_actuator_type("torque", {pexod->dof_names()[0]});
-    BOOST_CHECK(pexod->actuator_type(pexod->dof_names()[0]) == "torque");
+    pexod->set_actuator_type("torque", {pexod->joint_names()[0]});
+    BOOST_CHECK(pexod->actuator_type(pexod->joint_names()[0]) == "torque");
 
     // enforce position limits to all DOFs
     pexod->set_position_enforced(true);

--- a/src/tests/test_robot.cpp
+++ b/src/tests/test_robot.cpp
@@ -75,34 +75,17 @@ BOOST_AUTO_TEST_CASE(test_actuators)
     pexod->fix_to_world();
 
     // set different actuator type to all DOFs
-    pexod->set_actuator_types(dart::dynamics::Joint::ActuatorType::PASSIVE);
+    pexod->set_actuator_type("passive", {}, true, true);
 
     // check if the change is applied
     auto types = pexod->actuator_types();
     for (size_t i = 0; i < types.size(); i++) {
-        BOOST_CHECK(types[i] == dart::dynamics::Joint::ActuatorType::PASSIVE);
-    }
-
-    // set different actuator type to specific DOFs
-    types[0] = dart::dynamics::Joint::ActuatorType::SERVO;
-    types[types.size() - 1] = dart::dynamics::Joint::ActuatorType::LOCKED;
-    pexod->set_actuator_types(types);
-
-    // check if the change is applied
-    types.clear();
-    types = pexod->actuator_types();
-    for (size_t i = 0; i < types.size(); i++) {
-        dart::dynamics::Joint::ActuatorType type = dart::dynamics::Joint::ActuatorType::PASSIVE;
-        if (i == 0)
-            type = dart::dynamics::Joint::ActuatorType::SERVO;
-        else if (i == types.size() - 1)
-            type = dart::dynamics::Joint::ActuatorType::LOCKED;
-        BOOST_CHECK(types[i] == type);
+        BOOST_CHECK(types[i] == "passive");
     }
 
     // check simple dof setting
-    pexod->set_actuator_type(0, dart::dynamics::Joint::ActuatorType::FORCE);
-    BOOST_CHECK(pexod->actuator_type(0) == dart::dynamics::Joint::ActuatorType::FORCE);
+    pexod->set_actuator_type("torque", {pexod->dof_names()[0]});
+    BOOST_CHECK(pexod->actuator_type(pexod->dof_names()[0]) == "torque");
 
     // enforce position limits to all DOFs
     pexod->set_position_enforced(true);

--- a/src/tests/test_robot.cpp
+++ b/src/tests/test_robot.cpp
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(test_actuators)
     pexod->fix_to_world();
 
     // set different actuator type to all DOFs
-    pexod->set_actuator_type("passive", {}, true, true);
+    pexod->set_actuator_types("passive", {}, true, true);
 
     // check if the change is applied
     auto types = pexod->actuator_types();
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(test_actuators)
     }
 
     // check simple dof setting
-    pexod->set_actuator_type("torque", {pexod->joint_names()[0]});
+    pexod->set_actuator_type("torque", pexod->joint_names()[0]);
     BOOST_CHECK(pexod->actuator_type(pexod->joint_names()[0]) == "torque");
 
     // enforce position limits to all DOFs


### PR DESCRIPTION
This PR adds aliases for `actuator types` of DART which we call `control modes`. @jbmouret I was thinking which control modes to provide to the user and I ended up with the conclusion that we should not provide any position control (either kinematic or dynamics with torques) as this would interfere with the control API. The user can use the step by step API to make a PID controller (they need to add one line of code!) and with the new functions they can change the control modes per dof/joint in a DART-free way (only by strings).