### PR TITLE
Possibility of displaying 3D axes

### DIFF
--- a/ci/install_magnum.sh
+++ b/ci/install_magnum.sh
@@ -34,7 +34,7 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     git clone https://github.com/mosra/magnum-integration.git
     cd magnum-integration
     mkdir build && cd build
-    cmake -DCMAKE_BUILD_TYPE=Release -DWITH_DART=ON ..
+    cmake -DCMAKE_BUILD_TYPE=Release -DWITH_DART=ON -DWITH_EIGEN=ON ..
     make -j
     sudo make install
     cd ../..

--- a/cmake/RobotDARTConfig.cmake.in
+++ b/cmake/RobotDARTConfig.cmake.in
@@ -46,7 +46,7 @@ set_target_properties(RobotDART::Simu PROPERTIES
 
 if(RobotDART_USE_MAGNUM)
   find_package(Magnum ${RobotDART_MAGNUM_REQUIRED} COMPONENTS @RobotDART_MAGNUM_DEP_LIBS@ CONFIG)
-  find_package(MagnumIntegration ${RobotDART_MAGNUM_REQUIRED} COMPONENTS Dart CONFIG)
+  find_package(MagnumIntegration ${RobotDART_MAGNUM_REQUIRED} COMPONENTS Dart Eigen CONFIG)
 
   if(Magnum_FOUND)
     set(RobotDARTMagnum_LIBRARY ${RobotDART_LIBRARY_DIRS}/libRobotDARTMagnum@RobotDART_LIB_TYPE@)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -134,12 +134,12 @@ cmake -DWITH_ASSIMPIMPORTER=ON -DWITH_DDSIMPORTER=ON -DWITH_JPEGIMPORTER=ON -DWI
 make -j
 sudo make install
 
-# installation of Magnum DART Integration (DART needs to be installed)
+# installation of Magnum DART Integration (DART needs to be installed) and Eigen Integration
 cd /path/to/tmp/folder
 git clone https://github.com/mosra/magnum-integration.git
 cd magnum-integration
 mkdir build && cd build
-cmake -DWITH_DART=ON ..
+cmake -DWITH_DART=ON -DWITH_EIGEN=ON ..
 make -j
 sudo make install
 ```

--- a/src/python/gui.cpp
+++ b/src/python/gui.cpp
@@ -92,7 +92,7 @@ namespace robot_dart {
                     py::arg("shadow_map_size") = 1024,
                     py::arg("max_lights") = 3,
                     py::arg("draw_main_camera") = true,
-                    py::arg("draw_ghosts") = true)
+                    py::arg("draw_debug") = true)
 
                 .def_readwrite("width", &GraphicsConfiguration::width)
                 .def_readwrite("height", &GraphicsConfiguration::height)
@@ -239,8 +239,8 @@ namespace robot_dart {
 
                 .def("camera", (Camera & (gui::magnum::CameraOSR::*)()) & gui::magnum::CameraOSR::camera, py::return_value_policy::reference)
 
-                .def("drawing_ghosts", &gui::magnum::CameraOSR::drawing_ghosts)
-                .def("draw_ghost", &gui::magnum::CameraOSR::draw_ghost,
+                .def("drawing_debug", &gui::magnum::CameraOSR::drawing_debug)
+                .def("draw_debug", &gui::magnum::CameraOSR::draw_debug,
                     py::arg("draw") = true);
 
             // Helper functions

--- a/src/python/robot.cpp
+++ b/src/python/robot.cpp
@@ -221,6 +221,14 @@ namespace robot_dart {
                     py::arg("ghost") = true)
                 .def("ghost", &Robot::ghost)
 
+                .def("set_draw_axis", &Robot::set_draw_axis,
+                    py::arg("body_name"),
+                    py::arg("draw") = true)
+
+                .def("remove_all_drawing_axis", &Robot::remove_all_drawing_axis)
+
+                // .def("drawing_axes", &Robot::drawing_axes)
+
                 .def_static("create_box", &Robot::create_box,
                     py::arg("dims"),
                     py::arg("pose") = Eigen::Vector6d::Zero(),

--- a/src/python/robot.cpp
+++ b/src/python/robot.cpp
@@ -223,6 +223,7 @@ namespace robot_dart {
 
                 .def("set_draw_axis", &Robot::set_draw_axis,
                     py::arg("body_name"),
+                    py::arg("size") = 0.25,
                     py::arg("draw") = true)
 
                 .def("remove_all_drawing_axis", &Robot::remove_all_drawing_axis)

--- a/src/robot_dart/gui/magnum/base_application.hpp
+++ b/src/robot_dart/gui/magnum/base_application.hpp
@@ -19,6 +19,7 @@
 
 #include <Magnum/GL/CubeMapTextureArray.h>
 #include <Magnum/GL/Framebuffer.h>
+#include <Magnum/GL/Mesh.h>
 #include <Magnum/GL/TextureArray.h>
 #include <Magnum/Platform/GLContext.h>
 #ifndef MAGNUM_MAC_OSX
@@ -26,6 +27,7 @@
 #else
 #include <Magnum/Platform/WindowlessCglApplication.h>
 #endif
+#include <Magnum/Shaders/VertexColor.h>
 
 #include <Magnum/DartIntegration/World.h>
 
@@ -146,6 +148,10 @@ namespace robot_dart {
                 // Image filled with depth buffer values
                 GrayscaleImage raw_depth_image();
 
+                // Access to members
+                Magnum::Shaders::VertexColor3D& axes_shader() { return *_3D_axis_shader; }
+                Magnum::GL::Mesh& axes_mesh() { return *_3D_axis_mesh; }
+
             protected:
                 /* Magnum */
                 Scene3D _scene;
@@ -177,6 +183,12 @@ namespace robot_dart {
                 int _shadow_map_size = 512;
                 std::unique_ptr<Camera3D> _shadow_camera;
                 Object3D* _shadow_camera_object;
+
+                /* Debug visualization */
+                std::unique_ptr<Magnum::GL::Mesh> _3D_axis_mesh;
+                std::unique_ptr<Magnum::Shaders::VertexColor3D> _3D_axis_shader;
+
+                /* Importer */
                 Corrade::PluginManager::Manager<Magnum::Trade::AbstractImporter> _importer_manager;
 
                 void _gl_clean_up();

--- a/src/robot_dart/gui/magnum/base_application.hpp
+++ b/src/robot_dart/gui/magnum/base_application.hpp
@@ -99,7 +99,7 @@ namespace robot_dart {
 
                 // These options are only for the main camera
                 bool draw_main_camera = true;
-                bool draw_ghosts = true;
+                bool draw_debug = true;
             };
 
             class BaseApplication {

--- a/src/robot_dart/gui/magnum/base_graphics.hpp
+++ b/src/robot_dart/gui/magnum/base_graphics.hpp
@@ -9,7 +9,7 @@
 // We need this for CORRADE_RESOURCE_INITIALIZE
 #include <Corrade/Utility/Resource.h>
 
-static void robot_dart_initialize_magnum_resources()
+inline static void robot_dart_initialize_magnum_resources()
 {
     CORRADE_RESOURCE_INITIALIZE(RobotDARTShaders);
 }

--- a/src/robot_dart/gui/magnum/camera_osr.cpp
+++ b/src/robot_dart/gui/magnum/camera_osr.cpp
@@ -17,8 +17,8 @@
 namespace robot_dart {
     namespace gui {
         namespace magnum {
-            CameraOSR::CameraOSR(RobotDARTSimu* simu, BaseApplication* app, size_t width, size_t height, bool draw_ghost)
-                : Base(), _simu(simu), _magnum_app(app), _enabled(true), _done(false), _draw_ghosts(draw_ghost)
+            CameraOSR::CameraOSR(RobotDARTSimu* simu, BaseApplication* app, size_t width, size_t height, bool draw_debug)
+                : Base(), _simu(simu), _magnum_app(app), _enabled(true), _done(false), _draw_debug(draw_debug)
             {
                 /* Camera setup */
                 _camera.reset(
@@ -115,7 +115,7 @@ namespace robot_dart {
                 _framebuffer.clear(Magnum::GL::FramebufferClear::Color | Magnum::GL::FramebufferClear::Depth);
 
                 /* Draw with this camera */
-                _camera->draw(_magnum_app->drawables(), _framebuffer, _format, _simu, _magnum_app->axes_shader(), _magnum_app->axes_mesh(), _draw_ghosts);
+                _camera->draw(_magnum_app->drawables(), _framebuffer, _format, _simu, _magnum_app->axes_shader(), _magnum_app->axes_mesh(), _draw_debug);
             }
 
             GrayscaleImage CameraOSR::depth_image()

--- a/src/robot_dart/gui/magnum/camera_osr.cpp
+++ b/src/robot_dart/gui/magnum/camera_osr.cpp
@@ -18,7 +18,7 @@ namespace robot_dart {
     namespace gui {
         namespace magnum {
             CameraOSR::CameraOSR(RobotDARTSimu* simu, BaseApplication* app, size_t width, size_t height, bool draw_ghost)
-                : Base(), _magnum_app(app), _enabled(true), _done(false), _draw_ghosts(draw_ghost)
+                : Base(), _simu(simu), _magnum_app(app), _enabled(true), _done(false), _draw_ghosts(draw_ghost)
             {
                 /* Camera setup */
                 _camera.reset(
@@ -115,7 +115,7 @@ namespace robot_dart {
                 _framebuffer.clear(Magnum::GL::FramebufferClear::Color | Magnum::GL::FramebufferClear::Depth);
 
                 /* Draw with this camera */
-                _camera->draw(_magnum_app->drawables(), _framebuffer, _format, _draw_ghosts);
+                _camera->draw(_magnum_app->drawables(), _framebuffer, _format, _simu, _magnum_app->axes_shader(), _magnum_app->axes_mesh(), _draw_ghosts);
             }
 
             GrayscaleImage CameraOSR::depth_image()

--- a/src/robot_dart/gui/magnum/camera_osr.hpp
+++ b/src/robot_dart/gui/magnum/camera_osr.hpp
@@ -75,6 +75,7 @@ namespace robot_dart {
                 void draw_ghost(bool draw = true) { _draw_ghosts = draw; }
 
             protected:
+                RobotDARTSimu* _simu;
                 Magnum::GL::Framebuffer _framebuffer{Magnum::NoCreate};
                 Magnum::PixelFormat _format;
                 Magnum::GL::Renderbuffer _color, _depth;

--- a/src/robot_dart/gui/magnum/camera_osr.hpp
+++ b/src/robot_dart/gui/magnum/camera_osr.hpp
@@ -15,7 +15,7 @@ namespace robot_dart {
             class CameraOSR : public Base {
             public:
                 static constexpr int FPS = 30;
-                CameraOSR(RobotDARTSimu* simu, BaseApplication* app, size_t width, size_t height, bool draw_ghost = false);
+                CameraOSR(RobotDARTSimu* simu, BaseApplication* app, size_t width, size_t height, bool draw_debug = false);
                 ~CameraOSR() {}
 
                 bool done() const override { return _done; }
@@ -71,8 +71,8 @@ namespace robot_dart {
                 gs::Camera& camera() { return *_camera; }
                 const gs::Camera& camera() const { return *_camera; }
 
-                bool drawing_ghosts() const { return _draw_ghosts; }
-                void draw_ghost(bool draw = true) { _draw_ghosts = draw; }
+                bool drawing_debug() const { return _draw_debug; }
+                void draw_debug(bool draw = true) { _draw_debug = draw; }
 
             protected:
                 RobotDARTSimu* _simu;
@@ -89,7 +89,7 @@ namespace robot_dart {
 
                 std::unique_ptr<gs::Camera> _camera;
 
-                bool _draw_ghosts;
+                bool _draw_debug;
             };
         } // namespace magnum
     } // namespace gui

--- a/src/robot_dart/gui/magnum/glfw_application.cpp
+++ b/src/robot_dart/gui/magnum/glfw_application.cpp
@@ -17,7 +17,7 @@ namespace robot_dart {
                   _speed_move(0.f),
                   _speed_strafe(0.f),
                   _draw_main_camera(configuration.draw_main_camera),
-                  _draw_ghosts(configuration.draw_ghosts)
+                  _draw_debug(configuration.draw_debug)
             {
                 /* Try 16x MSAA */
                 Configuration conf;
@@ -81,7 +81,7 @@ namespace robot_dart {
                     _camera->strafe(_speed_strafe);
 
                     /* Draw with main camera */
-                    _camera->draw(_drawables, Magnum::GL::defaultFramebuffer, Magnum::PixelFormat::RGB8Unorm, _simu, *_3D_axis_shader, *_3D_axis_mesh, _draw_ghosts);
+                    _camera->draw(_drawables, Magnum::GL::defaultFramebuffer, Magnum::PixelFormat::RGB8Unorm, _simu, *_3D_axis_shader, *_3D_axis_mesh, _draw_debug);
 
                     swapBuffers();
                 }

--- a/src/robot_dart/gui/magnum/glfw_application.cpp
+++ b/src/robot_dart/gui/magnum/glfw_application.cpp
@@ -13,6 +13,7 @@ namespace robot_dart {
             GlfwApplication::GlfwApplication(int argc, char** argv, RobotDARTSimu* simu, const GraphicsConfiguration& configuration)
                 : BaseApplication(configuration),
                   Magnum::Platform::Application({argc, argv}, Magnum::NoCreate),
+                  _simu(simu),
                   _speed_move(0.f),
                   _speed_strafe(0.f),
                   _draw_main_camera(configuration.draw_main_camera),
@@ -80,7 +81,7 @@ namespace robot_dart {
                     _camera->strafe(_speed_strafe);
 
                     /* Draw with main camera */
-                    _camera->draw(_drawables, Magnum::GL::defaultFramebuffer, Magnum::PixelFormat::RGB8Unorm, _draw_ghosts);
+                    _camera->draw(_drawables, Magnum::GL::defaultFramebuffer, Magnum::PixelFormat::RGB8Unorm, _simu, *_3D_axis_shader, *_3D_axis_mesh, _draw_ghosts);
 
                     swapBuffers();
                 }

--- a/src/robot_dart/gui/magnum/glfw_application.hpp
+++ b/src/robot_dart/gui/magnum/glfw_application.hpp
@@ -25,7 +25,7 @@ namespace robot_dart {
             protected:
                 RobotDARTSimu* _simu;
                 Magnum::Float _speed_move, _speed_strafe;
-                bool _draw_main_camera, _draw_ghosts;
+                bool _draw_main_camera, _draw_debug;
 
                 static constexpr Magnum::Float _speed = 0.05f;
 

--- a/src/robot_dart/gui/magnum/glfw_application.hpp
+++ b/src/robot_dart/gui/magnum/glfw_application.hpp
@@ -23,6 +23,7 @@ namespace robot_dart {
                 void render() override;
 
             protected:
+                RobotDARTSimu* _simu;
                 Magnum::Float _speed_move, _speed_strafe;
                 bool _draw_main_camera, _draw_ghosts;
 

--- a/src/robot_dart/gui/magnum/gs/camera.cpp
+++ b/src/robot_dart/gui/magnum/gs/camera.cpp
@@ -250,10 +250,10 @@ namespace robot_dart {
 
                     /* Draw debug */
                     if (draw_debug) {
-                        std::vector<dart::dynamics::BodyNode*> axes = simu->gui_data()->drawing_axes();
+                        std::vector<std::pair<dart::dynamics::BodyNode*, double>> axes = simu->gui_data()->drawing_axes();
                         for (auto& axis : axes) {
-                            Magnum::Matrix4 world_transform = Magnum::Matrix4(Magnum::Matrix4d(axis->getWorldTransform().matrix()));
-                            Magnum::Matrix4 scaling = Magnum::Matrix4::scaling({0.25f, 0.25f, 0.25f});
+                            Magnum::Matrix4 world_transform = Magnum::Matrix4(Magnum::Matrix4d(axis.first->getWorldTransform().matrix()));
+                            Magnum::Matrix4 scaling = Magnum::Matrix4::scaling(Magnum::Vector3(axis.second, axis.second, axis.second));
 
                             axes_shader.setTransformationProjectionMatrix(_camera->projectionMatrix() * _camera->cameraMatrix() * world_transform * scaling)
                                 .draw(axes_mesh);

--- a/src/robot_dart/gui/magnum/gs/camera.cpp
+++ b/src/robot_dart/gui/magnum/gs/camera.cpp
@@ -220,7 +220,7 @@ namespace robot_dart {
 #endif
                 }
 
-                void Camera::draw(Magnum::SceneGraph::DrawableGroup3D& drawables, Magnum::GL::AbstractFramebuffer& framebuffer, Magnum::PixelFormat format, RobotDARTSimu* simu, Magnum::Shaders::VertexColor3D& axes_shader, Magnum::GL::Mesh& axes_mesh, bool draw_ghost)
+                void Camera::draw(Magnum::SceneGraph::DrawableGroup3D& drawables, Magnum::GL::AbstractFramebuffer& framebuffer, Magnum::PixelFormat format, RobotDARTSimu* simu, Magnum::Shaders::VertexColor3D& axes_shader, Magnum::GL::Mesh& axes_mesh, bool draw_debug)
                 {
                     // TO-DO: Maybe check if world moved?
                     std::vector<std::pair<std::reference_wrapper<Magnum::SceneGraph::Drawable3D>, Magnum::Matrix4>>
@@ -229,7 +229,7 @@ namespace robot_dart {
                     std::vector<std::pair<std::reference_wrapper<Magnum::SceneGraph::Drawable3D>, Magnum::Matrix4>> opaque, transparent;
                     for (size_t i = 0; i < drawableTransformations.size(); i++) {
                         auto& obj = static_cast<DrawableObject&>(drawableTransformations[i].first.get().object());
-                        if (!draw_ghost && simu->gui_data()->ghost(obj.shape()))
+                        if (!draw_debug && simu->gui_data()->ghost(obj.shape()))
                             continue;
                         if (obj.transparent())
                             transparent.emplace_back(drawableTransformations[i]);
@@ -249,13 +249,15 @@ namespace robot_dart {
                     }
 
                     /* Draw debug */
-                    std::vector<dart::dynamics::BodyNode*> axes = simu->gui_data()->drawing_axes();
-                    for (auto& axis : axes) {
-                        Magnum::Matrix4 world_transform = Magnum::Matrix4(Magnum::Matrix4d(axis->getWorldTransform().matrix()));
-                        Magnum::Matrix4 scaling = Magnum::Matrix4::scaling({0.25f, 0.25f, 0.25f});
+                    if (draw_debug) {
+                        std::vector<dart::dynamics::BodyNode*> axes = simu->gui_data()->drawing_axes();
+                        for (auto& axis : axes) {
+                            Magnum::Matrix4 world_transform = Magnum::Matrix4(Magnum::Matrix4d(axis->getWorldTransform().matrix()));
+                            Magnum::Matrix4 scaling = Magnum::Matrix4::scaling({0.25f, 0.25f, 0.25f});
 
-                        axes_shader.setTransformationProjectionMatrix(_camera->projectionMatrix() * _camera->cameraMatrix() * world_transform * scaling)
-                            .draw(axes_mesh);
+                            axes_shader.setTransformationProjectionMatrix(_camera->projectionMatrix() * _camera->cameraMatrix() * world_transform * scaling)
+                                .draw(axes_mesh);
+                        }
                     }
 
                     if (_recording) {

--- a/src/robot_dart/gui/magnum/gs/camera.hpp
+++ b/src/robot_dart/gui/magnum/gs/camera.hpp
@@ -68,7 +68,7 @@ namespace robot_dart {
                     Corrade::Containers::Optional<Magnum::Image2D>& image() { return _image; }
                     Corrade::Containers::Optional<Magnum::Image2D>& depth_image() { return _depth_image; }
 
-                    void draw(Magnum::SceneGraph::DrawableGroup3D& drawables, Magnum::GL::AbstractFramebuffer& framebuffer, Magnum::PixelFormat format, RobotDARTSimu* simu, Magnum::Shaders::VertexColor3D& axes_shader, Magnum::GL::Mesh& axes_mesh, bool draw_ghost = true);
+                    void draw(Magnum::SceneGraph::DrawableGroup3D& drawables, Magnum::GL::AbstractFramebuffer& framebuffer, Magnum::PixelFormat format, RobotDARTSimu* simu, Magnum::Shaders::VertexColor3D& axes_shader, Magnum::GL::Mesh& axes_mesh, bool draw_debug = true);
 
                 private:
                     Object3D* _yaw_object;

--- a/src/robot_dart/gui/magnum/gs/camera.hpp
+++ b/src/robot_dart/gui/magnum/gs/camera.hpp
@@ -3,6 +3,7 @@
 
 #include <robot_dart/gui/magnum/gs/light.hpp>
 #include <robot_dart/gui/magnum/types.hpp>
+#include <robot_dart/robot_dart_simu.hpp>
 
 #include <boost/version.hpp>
 #if ((BOOST_VERSION / 100000) > 1) || ((BOOST_VERSION / 100000) == 1 && ((BOOST_VERSION / 100 % 1000) >= 64))
@@ -13,7 +14,9 @@
 #endif
 
 #include <Corrade/Containers/Optional.h>
+#include <Magnum/GL/Mesh.h>
 #include <Magnum/Image.h>
+#include <Magnum/Shaders/VertexColor.h>
 
 namespace robot_dart {
     namespace gui {
@@ -65,7 +68,7 @@ namespace robot_dart {
                     Corrade::Containers::Optional<Magnum::Image2D>& image() { return _image; }
                     Corrade::Containers::Optional<Magnum::Image2D>& depth_image() { return _depth_image; }
 
-                    void draw(Magnum::SceneGraph::DrawableGroup3D& drawables, Magnum::GL::AbstractFramebuffer& framebuffer, Magnum::PixelFormat format, bool draw_ghost = true);
+                    void draw(Magnum::SceneGraph::DrawableGroup3D& drawables, Magnum::GL::AbstractFramebuffer& framebuffer, Magnum::PixelFormat format, RobotDARTSimu* simu, Magnum::Shaders::VertexColor3D& axes_shader, Magnum::GL::Mesh& axes_mesh, bool draw_ghost = true);
 
                 private:
                     Object3D* _yaw_object;

--- a/src/robot_dart/gui/magnum/windowless_gl_application.cpp
+++ b/src/robot_dart/gui/magnum/windowless_gl_application.cpp
@@ -12,7 +12,7 @@ namespace robot_dart {
                   Magnum::Platform::WindowlessApplication({argc, argv}, Magnum::NoCreate),
                   _simu(simu),
                   _draw_main_camera(configuration.draw_main_camera),
-                  _draw_ghosts(configuration.draw_ghosts)
+                  _draw_debug(configuration.draw_debug)
             {
                 /* Assume context is given externally, if not create it */
                 if (!Magnum::GL::Context::hasCurrent()) {
@@ -74,7 +74,7 @@ namespace robot_dart {
                     _framebuffer.clear(Magnum::GL::FramebufferClear::Color | Magnum::GL::FramebufferClear::Depth);
 
                     /* Draw with main camera */
-                    _camera->draw(_drawables, _framebuffer, _format, _simu, *_3D_axis_shader, *_3D_axis_mesh, _draw_ghosts);
+                    _camera->draw(_drawables, _framebuffer, _format, _simu, *_3D_axis_shader, *_3D_axis_mesh, _draw_debug);
 
                     // if (_index % 10 == 0) {
                     //     intptr_t tt = (intptr_t)_glx_context;

--- a/src/robot_dart/gui/magnum/windowless_gl_application.cpp
+++ b/src/robot_dart/gui/magnum/windowless_gl_application.cpp
@@ -10,6 +10,7 @@ namespace robot_dart {
             WindowlessGLApplication::WindowlessGLApplication(int argc, char** argv, RobotDARTSimu* simu, const GraphicsConfiguration& configuration)
                 : BaseApplication(configuration),
                   Magnum::Platform::WindowlessApplication({argc, argv}, Magnum::NoCreate),
+                  _simu(simu),
                   _draw_main_camera(configuration.draw_main_camera),
                   _draw_ghosts(configuration.draw_ghosts)
             {
@@ -73,7 +74,7 @@ namespace robot_dart {
                     _framebuffer.clear(Magnum::GL::FramebufferClear::Color | Magnum::GL::FramebufferClear::Depth);
 
                     /* Draw with main camera */
-                    _camera->draw(_drawables, _framebuffer, _format, _draw_ghosts);
+                    _camera->draw(_drawables, _framebuffer, _format, _simu, *_3D_axis_shader, *_3D_axis_mesh, _draw_ghosts);
 
                     // if (_index % 10 == 0) {
                     //     intptr_t tt = (intptr_t)_glx_context;

--- a/src/robot_dart/gui/magnum/windowless_gl_application.hpp
+++ b/src/robot_dart/gui/magnum/windowless_gl_application.hpp
@@ -17,6 +17,7 @@ namespace robot_dart {
                 void render() override;
 
             protected:
+                RobotDARTSimu* _simu;
                 bool _draw_main_camera, _draw_ghosts;
 
                 Magnum::GL::Framebuffer _framebuffer{Magnum::NoCreate};

--- a/src/robot_dart/gui/magnum/windowless_gl_application.hpp
+++ b/src/robot_dart/gui/magnum/windowless_gl_application.hpp
@@ -18,7 +18,7 @@ namespace robot_dart {
 
             protected:
                 RobotDARTSimu* _simu;
-                bool _draw_main_camera, _draw_ghosts;
+                bool _draw_main_camera, _draw_debug;
 
                 Magnum::GL::Framebuffer _framebuffer{Magnum::NoCreate};
                 Magnum::PixelFormat _format;

--- a/src/robot_dart/gui_data.hpp
+++ b/src/robot_dart/gui_data.hpp
@@ -18,7 +18,7 @@ namespace robot_dart {
             };
 
             std::unordered_map<dart::dynamics::ShapeNode*, RobotData> robot_data;
-            std::unordered_map<Robot*, std::vector<dart::dynamics::BodyNode*>> robot_axes;
+            std::unordered_map<Robot*, std::vector<std::pair<dart::dynamics::BodyNode*, double>>> robot_axes;
 
         public:
             void update_robot(const std::shared_ptr<Robot>& robot)
@@ -75,10 +75,10 @@ namespace robot_dart {
                 return false;
             }
 
-            std::vector<dart::dynamics::BodyNode*> drawing_axes() const
+            std::vector<std::pair<dart::dynamics::BodyNode*, double>> drawing_axes() const
             {
-                std::vector<dart::dynamics::BodyNode*> axes;
-                for (std::pair<Robot*, std::vector<dart::dynamics::BodyNode*>> elem : robot_axes) {
+                std::vector<std::pair<dart::dynamics::BodyNode*, double>> axes;
+                for (std::pair<Robot*, std::vector<std::pair<dart::dynamics::BodyNode*, double>>> elem : robot_axes) {
                     axes.insert(axes.end(), elem.second.begin(), elem.second.end());
                 }
 

--- a/src/robot_dart/gui_data.hpp
+++ b/src/robot_dart/gui_data.hpp
@@ -5,6 +5,7 @@
 
 #include <unordered_map>
 
+#include <dart/dynamics/BodyNode.hpp>
 #include <dart/dynamics/ShapeNode.hpp>
 
 namespace robot_dart {
@@ -17,21 +18,32 @@ namespace robot_dart {
             };
 
             std::unordered_map<dart::dynamics::ShapeNode*, RobotData> robot_data;
+            std::unordered_map<Robot*, std::vector<dart::dynamics::BodyNode*>> robot_axes;
 
         public:
             void update_robot(const std::shared_ptr<Robot>& robot)
             {
+                auto robot_ptr = &*robot;
                 auto skel = robot->skeleton();
                 bool cast = robot->cast_shadows();
                 bool ghost = robot->ghost();
-                for (size_t i = 0; i < skel->getNumShapeNodes(); ++i) {
-                    auto shape = skel->getShapeNode(i);
-                    robot_data[shape] = {cast, ghost};
+
+                for (size_t i = 0; i < skel->getNumBodyNodes(); ++i) {
+                    auto bd = skel->getBodyNode(i);
+                    auto& shapes = bd->getShapeNodesWith<dart::dynamics::VisualAspect>();
+                    for (size_t j = 0; j < shapes.size(); j++) {
+                        robot_data[shapes[j]] = {cast, ghost};
+                    }
                 }
+
+                auto& axes = robot->drawing_axes();
+                if (axes.size() > 0)
+                    robot_axes[robot_ptr] = axes;
             }
 
             void remove_robot(const std::shared_ptr<Robot>& robot)
             {
+                auto robot_ptr = &*robot;
                 auto skel = robot->skeleton();
                 for (size_t i = 0; i < skel->getNumShapeNodes(); ++i) {
                     auto shape = skel->getShapeNode(i);
@@ -39,6 +51,10 @@ namespace robot_dart {
                     if (shape_iter != robot_data.end())
                         robot_data.erase(shape_iter);
                 }
+
+                auto iter = robot_axes.find(robot_ptr);
+                if (iter != robot_axes.end())
+                    robot_axes.erase(iter);
             }
 
             bool cast_shadows(dart::dynamics::ShapeNode* shape) const
@@ -57,6 +73,16 @@ namespace robot_dart {
                     return robot_data.at(shape).is_ghost;
                 // if not in the array, the robot is not ghost by default
                 return false;
+            }
+
+            std::vector<dart::dynamics::BodyNode*> drawing_axes() const
+            {
+                std::vector<dart::dynamics::BodyNode*> axes;
+                for (std::pair<Robot*, std::vector<dart::dynamics::BodyNode*>> elem : robot_axes) {
+                    axes.insert(axes.end(), elem.second.begin(), elem.second.end());
+                }
+
+                return axes;
             }
         };
     } // namespace simu

--- a/src/robot_dart/robot.cpp
+++ b/src/robot_dart/robot.cpp
@@ -986,6 +986,22 @@ namespace robot_dart {
 
     bool Robot::ghost() const { return _is_ghost; }
 
+    void Robot::set_draw_axis(const std::string& body_name, bool draw)
+    {
+        auto bd = _skeleton->getBodyNode(body_name);
+        ROBOT_DART_ASSERT(bd, "Body name does not exist in skeleton", );
+        auto iter = std::find(_axis_shapes.begin(), _axis_shapes.end(), bd);
+        if (iter == _axis_shapes.end())
+            _axis_shapes.push_back(bd);
+    }
+
+    void Robot::remove_all_drawing_axis()
+    {
+        _axis_shapes.clear();
+    }
+
+    const std::vector<dart::dynamics::BodyNode*>& Robot::drawing_axes() const { return _axis_shapes; }
+
     dart::dynamics::SkeletonPtr Robot::_load_model(const std::string& filename, const std::vector<std::pair<std::string, std::string>>& packages, bool is_urdf_string)
     {
         // Remove spaces from beginning of the filename/path

--- a/src/robot_dart/robot.cpp
+++ b/src/robot_dart/robot.cpp
@@ -986,13 +986,14 @@ namespace robot_dart {
 
     bool Robot::ghost() const { return _is_ghost; }
 
-    void Robot::set_draw_axis(const std::string& body_name, bool draw)
+    void Robot::set_draw_axis(const std::string& body_name, double size, bool draw)
     {
         auto bd = _skeleton->getBodyNode(body_name);
         ROBOT_DART_ASSERT(bd, "Body name does not exist in skeleton", );
-        auto iter = std::find(_axis_shapes.begin(), _axis_shapes.end(), bd);
+        std::pair<dart::dynamics::BodyNode*, double> p = {bd, size};
+        auto iter = std::find(_axis_shapes.begin(), _axis_shapes.end(), p);
         if (iter == _axis_shapes.end())
-            _axis_shapes.push_back(bd);
+            _axis_shapes.push_back(p);
     }
 
     void Robot::remove_all_drawing_axis()
@@ -1000,7 +1001,7 @@ namespace robot_dart {
         _axis_shapes.clear();
     }
 
-    const std::vector<dart::dynamics::BodyNode*>& Robot::drawing_axes() const { return _axis_shapes; }
+    const std::vector<std::pair<dart::dynamics::BodyNode*, double>>& Robot::drawing_axes() const { return _axis_shapes; }
 
     dart::dynamics::SkeletonPtr Robot::_load_model(const std::string& filename, const std::vector<std::pair<std::string, std::string>>& packages, bool is_urdf_string)
     {

--- a/src/robot_dart/robot.hpp
+++ b/src/robot_dart/robot.hpp
@@ -169,6 +169,10 @@ namespace robot_dart {
         void set_ghost(bool ghost = true);
         bool ghost() const;
 
+        void set_draw_axis(const std::string& body_name, bool draw = true);
+        void remove_all_drawing_axis();
+        const std::vector<dart::dynamics::BodyNode*>& drawing_axes() const;
+
         // helper functions
         // pose: Orientation-Position
         static std::shared_ptr<Robot> create_box(const Eigen::Vector3d& dims, const Eigen::Vector6d& pose = Eigen::Vector6d::Zero(), const std::string& type = "free", double mass = 1.0, const Eigen::Vector4d& color = dart::Color::Red(1.0), const std::string& box_name = "box");
@@ -189,6 +193,7 @@ namespace robot_dart {
         std::unordered_map<std::string, size_t> _dof_map, _joint_map;
         bool _cast_shadows;
         bool _is_ghost;
+        std::vector<dart::dynamics::BodyNode*> _axis_shapes;
     };
 } // namespace robot_dart
 

--- a/src/robot_dart/robot.hpp
+++ b/src/robot_dart/robot.hpp
@@ -169,9 +169,9 @@ namespace robot_dart {
         void set_ghost(bool ghost = true);
         bool ghost() const;
 
-        void set_draw_axis(const std::string& body_name, bool draw = true);
+        void set_draw_axis(const std::string& body_name, double size = 0.25, bool draw = true);
         void remove_all_drawing_axis();
-        const std::vector<dart::dynamics::BodyNode*>& drawing_axes() const;
+        const std::vector<std::pair<dart::dynamics::BodyNode*, double>>& drawing_axes() const;
 
         // helper functions
         // pose: Orientation-Position
@@ -193,7 +193,7 @@ namespace robot_dart {
         std::unordered_map<std::string, size_t> _dof_map, _joint_map;
         bool _cast_shadows;
         bool _is_ghost;
-        std::vector<dart::dynamics::BodyNode*> _axis_shapes;
+        std::vector<std::pair<dart::dynamics::BodyNode*, double>> _axis_shapes;
     };
 } // namespace robot_dart
 

--- a/wscript
+++ b/wscript
@@ -75,7 +75,7 @@ def configure(conf):
         conf.check_magnum(components=conf.env['magnum_dep_libs'], required=False)
     if len(conf.env.INCLUDES_Magnum):
         conf.check_magnum_plugins(components='AssimpImporter', required=False)
-        conf.check_magnum_integration(components='Dart', required=False)
+        conf.check_magnum_integration(components='Dart Eigen', required=False)
 
     conf.env['py_flags'] = ''
     conf.env['BUILD_PYTHON'] = False
@@ -89,9 +89,10 @@ def configure(conf):
         if conf.env.CXX_NAME in ["gcc", "g++"]:
             conf.env['py_flags'] = ' -fPIC' # we need -fPIC in some Linux/gcc combinations
 
-    if len(conf.env.INCLUDES_MagnumIntegration) > 0:
+    # We require both Magnum DartIntegration and EigenIntegration
+    if len(conf.env.INCLUDES_MagnumIntegration_Dart) > 0 and len(conf.env.INCLUDES_MagnumIntegration_Eigen) > 0:
         conf.get_env()['BUILD_MAGNUM'] = True
-        conf.env['magnum_libs'] = magnum.get_magnum_dependency_libs(conf, conf.env['magnum_dep_libs']) + magnum_integration.get_magnum_integration_dependency_libs(conf, 'Dart')
+        conf.env['magnum_libs'] = magnum.get_magnum_dependency_libs(conf, conf.env['magnum_dep_libs']) + magnum_integration.get_magnum_integration_dependency_libs(conf, 'Dart Eigen')
 
     avx_dart = conf.check_avx(lib='dart', required=['dart', 'dart-utils', 'dart-utils-urdf'])
 


### PR DESCRIPTION
This PR makes a few minor fixes in the `GuiData` and adds the possibility of display 3D axes. Here's an example:

![image](https://user-images.githubusercontent.com/1283922/83978395-d4527a00-a90f-11ea-84b6-4f8a0cac41ad.png)

These changes require to use the `Magnum EigenIntegration` but this is harmless as we just need to do just one `-DWITH_EIGEN=ON` when building `magnum-integration`. With a small restructure, now it is possible to more easily add more debug drawings if needed in the future.