### PR TITLE
Fix a detection problem with CMake and old versions of Eigen3

### DIFF
--- a/cmake/RobotDARTConfig.cmake.in
+++ b/cmake/RobotDARTConfig.cmake.in
@@ -10,7 +10,14 @@ include(FindPackageHandleStandardArgs)
 # CMAKE_MODULE_PATH
 set(CMAKE_MODULE_PATH "@RobotDART_CMAKE_MODULE_PATH@")
 
-find_dependency(Eigen3 3.2.92 REQUIRED NO_MODULE)
+find_package(Eigen3 REQUIRED CONFIG)
+if(EIGEN3_VERSION_STRING VERSION_LESS 3.2.92)  # 3.3~beta1
+  message(FATAL_ERROR "Eigen3 ${EIGEN3_VERSION_STRING} is found but >= 3.2.92 "
+    "(3.3~beta1) is required"
+  )
+endif()
+
+
 find_dependency(DART 6.0.0 REQUIRED COMPONENTS utils-urdf @DART_EXTRA_LIBS@ CONFIG)
 
 # Look for components (ie. libraries)


### PR DESCRIPTION
Apparently the version check does not work with old version of eigen (which defeats the purpose). This new detection uses the code from dart.