### PR TITLE
Add jacobian, mass matrix and other helpers in Robot

### DIFF
--- a/src/python/robot.cpp
+++ b/src/python/robot.cpp
@@ -294,6 +294,10 @@ namespace robot_dart {
                 .def("coriolis_gravity_forces", &Robot::coriolis_gravity_forces,
                     py::arg("dof_names") = std::vector<std::string>())
 
+                .def("vec_dof", &Robot::vec_dof,
+                    py::arg("vec"),
+                    py::arg("dof_names"))
+
                 .def("update_joint_dof_maps", &Robot::update_joint_dof_maps)
                 .def("dof_map", &Robot::dof_map)
                 .def("joint_map", &Robot::joint_map)

--- a/src/python/robot.cpp
+++ b/src/python/robot.cpp
@@ -245,6 +245,15 @@ namespace robot_dart {
                 .def("body_pose", (Eigen::Isometry3d(Robot::*)(const std::string& body_name) const) & Robot::body_pose)
                 .def("body_pose", (Eigen::Isometry3d(Robot::*)(size_t body_index) const) & Robot::body_pose)
 
+                .def("body_pose_vec", (Eigen::Vector6d(Robot::*)(const std::string& body_name) const) & Robot::body_pose_vec)
+                .def("body_pose_vec", (Eigen::Vector6d(Robot::*)(size_t body_index) const) & Robot::body_pose_vec)
+
+                .def("body_velocity", (Eigen::Vector6d(Robot::*)(const std::string& body_name) const) & Robot::body_velocity)
+                .def("body_velocity", (Eigen::Vector6d(Robot::*)(size_t body_index) const) & Robot::body_velocity)
+
+                .def("body_acceleration", (Eigen::Vector6d(Robot::*)(const std::string& body_name) const) & Robot::body_acceleration)
+                .def("body_acceleration", (Eigen::Vector6d(Robot::*)(size_t body_index) const) & Robot::body_acceleration)
+
                 .def("body_names", &Robot::body_names)
                 .def("body_name", &Robot::body_name)
                 .def("set_body_name", &Robot::set_body_name)
@@ -256,6 +265,34 @@ namespace robot_dart {
                 .def("set_body_mass", (void (Robot::*)(size_t body_index, double mass)) & Robot::set_body_mass)
                 .def("add_body_mass", (void (Robot::*)(const std::string& body_name, double mass)) & Robot::add_body_mass)
                 .def("add_body_mass", (void (Robot::*)(size_t body_index, double mass)) & Robot::add_body_mass)
+
+                .def("jacobian", &Robot::jacobian,
+                    py::arg("body_name"),
+                    py::arg("dof_names") = std::vector<std::string>())
+                .def("jacobian_deriv", &Robot::jacobian_deriv,
+                    py::arg("body_name"),
+                    py::arg("dof_names") = std::vector<std::string>())
+
+                .def("com_jacobian", &Robot::com_jacobian,
+                    py::arg("dof_names") = std::vector<std::string>())
+                .def("com_jacobian_deriv", &Robot::com_jacobian_deriv,
+                    py::arg("dof_names") = std::vector<std::string>())
+
+                .def("mass_matrix", &Robot::mass_matrix,
+                    py::arg("dof_names") = std::vector<std::string>())
+                .def("aug_mass_matrix", &Robot::aug_mass_matrix,
+                    py::arg("dof_names") = std::vector<std::string>())
+                .def("inv_mass_matrix", &Robot::inv_mass_matrix,
+                    py::arg("dof_names") = std::vector<std::string>())
+                .def("inv_aug_mass_matrix", &Robot::inv_aug_mass_matrix,
+                    py::arg("dof_names") = std::vector<std::string>())
+
+                .def("coriolis_forces", &Robot::coriolis_forces,
+                    py::arg("dof_names") = std::vector<std::string>())
+                .def("gravity_forces", &Robot::gravity_forces,
+                    py::arg("dof_names") = std::vector<std::string>())
+                .def("coriolis_gravity_forces", &Robot::coriolis_gravity_forces,
+                    py::arg("dof_names") = std::vector<std::string>())
 
                 .def("update_joint_dof_maps", &Robot::update_joint_dof_maps)
                 .def("dof_map", &Robot::dof_map)

--- a/src/robot_dart/robot.cpp
+++ b/src/robot_dart/robot.cpp
@@ -1238,6 +1238,22 @@ namespace robot_dart {
         return detail::dof_data<15>(_skeleton, dof_names, _dof_map);
     }
 
+    Eigen::VectorXd Robot::vec_dof(const Eigen::VectorXd& vec, const std::vector<std::string>& dof_names) const
+    {
+        assert(vec.size() == static_cast<int>(_skeleton->getNumDofs()));
+
+        Eigen::VectorXd ret(dof_names.size());
+        for (size_t i = 0; i < dof_names.size(); i++) {
+            auto it = _dof_map.find(dof_names[i]);
+            ROBOT_DART_ASSERT(
+                it != _dof_map.end(), "vec_dof: " + dof_names[i] + " is not in dof_map", Eigen::VectorXd());
+
+            ret(i) = vec[it->second];
+        }
+
+        return ret;
+    }
+
     void Robot::update_joint_dof_maps()
     {
         // DoFs

--- a/src/robot_dart/robot.hpp
+++ b/src/robot_dart/robot.hpp
@@ -163,6 +163,15 @@ namespace robot_dart {
         Eigen::Isometry3d body_pose(const std::string& body_name) const;
         Eigen::Isometry3d body_pose(size_t body_index) const;
 
+        Eigen::Vector6d body_pose_vec(const std::string& body_name) const;
+        Eigen::Vector6d body_pose_vec(size_t body_index) const;
+
+        Eigen::Vector6d body_velocity(const std::string& body_name) const;
+        Eigen::Vector6d body_velocity(size_t body_index) const;
+
+        Eigen::Vector6d body_acceleration(const std::string& body_name) const;
+        Eigen::Vector6d body_acceleration(size_t body_index) const;
+
         std::vector<std::string> body_names() const;
         std::string body_name(size_t body_index) const;
         void set_body_name(size_t body_index, const std::string& body_name);
@@ -173,6 +182,21 @@ namespace robot_dart {
         void set_body_mass(size_t body_index, double mass);
         void add_body_mass(const std::string& body_name, double mass);
         void add_body_mass(size_t body_index, double mass);
+
+        Eigen::MatrixXd jacobian(const std::string& body_name, const std::vector<std::string>& dof_names = {}) const;
+        Eigen::MatrixXd jacobian_deriv(const std::string& body_name, const std::vector<std::string>& dof_names = {}) const;
+
+        Eigen::MatrixXd com_jacobian(const std::vector<std::string>& dof_names = {}) const;
+        Eigen::MatrixXd com_jacobian_deriv(const std::vector<std::string>& dof_names = {}) const;
+
+        Eigen::MatrixXd mass_matrix(const std::vector<std::string>& dof_names = {}) const;
+        Eigen::MatrixXd aug_mass_matrix(const std::vector<std::string>& dof_names = {}) const;
+        Eigen::MatrixXd inv_mass_matrix(const std::vector<std::string>& dof_names = {}) const;
+        Eigen::MatrixXd inv_aug_mass_matrix(const std::vector<std::string>& dof_names = {}) const;
+
+        Eigen::VectorXd coriolis_forces(const std::vector<std::string>& dof_names = {}) const;
+        Eigen::VectorXd gravity_forces(const std::vector<std::string>& dof_names = {}) const;
+        Eigen::VectorXd coriolis_gravity_forces(const std::vector<std::string>& dof_names = {}) const;
 
         void update_joint_dof_maps();
         const std::unordered_map<std::string, size_t>& dof_map() const;
@@ -234,6 +258,9 @@ namespace robot_dart {
 
         dart::dynamics::Joint::ActuatorType _actuator_type(size_t joint_index) const;
         std::vector<dart::dynamics::Joint::ActuatorType> _actuator_types() const;
+
+        Eigen::MatrixXd _jacobian(const Eigen::MatrixXd& full_jacobian, const std::vector<std::string>& dof_names) const;
+        Eigen::MatrixXd _mass_matrix(const Eigen::MatrixXd& full_mass_matrix, const std::vector<std::string>& dof_names) const;
 
         std::string _robot_name;
         std::string _model_filename;

--- a/src/robot_dart/robot.hpp
+++ b/src/robot_dart/robot.hpp
@@ -198,6 +198,9 @@ namespace robot_dart {
         Eigen::VectorXd gravity_forces(const std::vector<std::string>& dof_names = {}) const;
         Eigen::VectorXd coriolis_gravity_forces(const std::vector<std::string>& dof_names = {}) const;
 
+        // Get only the part of vector for DOFs in dof_names
+        Eigen::VectorXd vec_dof(const Eigen::VectorXd& vec, const std::vector<std::string>& dof_names) const;
+
         void update_joint_dof_maps();
         const std::unordered_map<std::string, size_t>& dof_map() const;
         const std::unordered_map<std::string, size_t>& joint_map() const;


### PR DESCRIPTION
Add jacobian, mass matrix and other helpers in Robot. A few things to note:

- I have given the possibility of "cutting" a jacobian or a mass matrix to a view of only the DOFs of interest.
- Although this might be good for debugging or very specific purposes, you should not use these views to perform computations for control/estimation (if you do not know exactly what you are doing, you will most probably do everything wrong).
- You should do something like the following: `joint_torques = robot->vec_dof(robot->jacobian("my_end_effector").transpose()*end_effector_wrench);`.


