### PR TITLE
Make boost.process optional (but make it possible to record videos)

### DIFF
--- a/src/examples/cameras.cpp
+++ b/src/examples/cameras.cpp
@@ -26,8 +26,8 @@ int main()
 {
     std::srand(std::time(NULL));
 
-    std::vector<std::pair<std::string, std::string>> packages = {{"iiwa14", "iiwa/meshes"}};
-    auto global_robot = std::make_shared<robot_dart::Robot>("iiwa/iiwa14.urdf", packages);
+    std::vector<std::pair<std::string, std::string>> packages = {{"iiwa_description", "iiwa/iiwa_description"}};
+    auto global_robot = std::make_shared<robot_dart::Robot>("iiwa/iiwa.urdf", packages);
 
     global_robot->fix_to_world();
     global_robot->set_position_enforced(true);

--- a/src/robot_dart/gui/magnum/gs/camera.cpp
+++ b/src/robot_dart/gui/magnum/gs/camera.cpp
@@ -1,3 +1,5 @@
+#include <sys/errno.h>
+
 #include "camera.hpp"
 #include "robot_dart/gui/magnum/base_application.hpp"
 #include "robot_dart/gui_data.hpp"
@@ -234,7 +236,11 @@ namespace robot_dart {
                         argv[0] = (char*)"ffmpeg";
                         for (size_t i = 0; i < args.size(); ++i)
                             argv[i + 1] = (char*)args[i].c_str();
-                        execvp("ffmpeg", argv);
+                        int ret = execvp("ffmpeg", argv);
+                        if (ret == -1) {
+                            std::cerr << "Video recording: cannot execute ffmpeg! ["<< strerror(errno) << "]" << std::endl;
+                            exit(0); // we are in the fork
+                        }
                     }
 #endif
                 }

--- a/src/robot_dart/gui/magnum/gs/camera.cpp
+++ b/src/robot_dart/gui/magnum/gs/camera.cpp
@@ -230,7 +230,7 @@ namespace robot_dart {
                         args.push_back("quiet");
                         close(_video_fd[1]); // ffmpeg does not write here
                         dup2(_video_fd[0], STDIN_FILENO); // ffmpeg will read the fd[0] as stdin
-                        char** argv = (char**)calloc(args.size() + 1, sizeof(char*)); // we need the 0 at the end
+                        char** argv = (char**)calloc(args.size() + 2, sizeof(char*)); // we need the 0 at the end AND the ffffmpeg at the beginning
                         argv[0] = (char*)"ffmpeg";
                         for (size_t i = 0; i < args.size(); ++i)
                             argv[i + 1] = (char*)args[i].c_str();

--- a/src/robot_dart/gui/magnum/gs/camera.cpp
+++ b/src/robot_dart/gui/magnum/gs/camera.cpp
@@ -238,7 +238,7 @@ namespace robot_dart {
                             argv[i + 1] = (char*)args[i].c_str();
                         int ret = execvp("ffmpeg", argv);
                         if (ret == -1) {
-                            std::cerr << "Video recording: cannot execute ffmpeg! ["<< strerror(errno) << "]" << std::endl;
+                            std::cerr << "Video recording: cannot execute ffmpeg! [" << strerror(errno) << "]" << std::endl;
                             exit(0); // we are in the fork
                         }
                     }

--- a/src/robot_dart/gui/magnum/gs/camera.cpp
+++ b/src/robot_dart/gui/magnum/gs/camera.cpp
@@ -222,17 +222,18 @@ namespace robot_dart {
                     pipe(_video_fd);
                     //  Data written to fd[1] appears on (i.e., can be read from) fd[0].
                     _video_pid = fork();
-                    if (_video_pid != 0) {  // main process
+                    if (_video_pid != 0) { // main process
                         close(_video_fd[0]); // we close the input on this side
-                    } else { // ffmpeg process
+                    }
+                    else { // ffmpeg process
                         close(_video_fd[1]); // ffmpeg does not write here
                         dup2(_video_fd[0], STDIN_FILENO); // ffmpeg will read the fd[0] as stdin
-                        char** argv =  (char**) calloc(args.size() + 1, sizeof(char*)); // we need the 0 at the end
+                        char** argv = (char**)calloc(args.size() + 1, sizeof(char*)); // we need the 0 at the end
                         for (int i = 0; i < args.size(); ++i)
-                            argv[i] = (char*) args[i].c_str();
+                            argv[i] = (char*)args[i].c_str();
                         execvp("ffmpeg", argv);
                     }
-                   // ROBOT_DART_WARNING(true, "Boost version does not support 'boost.process'. Cannot record video!");
+                    // ROBOT_DART_WARNING(true, "Boost version does not support 'boost.process'. Cannot record video!");
 #endif
                 }
 
@@ -298,7 +299,6 @@ namespace robot_dart {
 #else
                         write(_video_fd[1], (char*)data.data(), data.size());
 #endif
-
                     }
                 }
             } // namespace gs

--- a/src/robot_dart/gui/magnum/gs/camera.cpp
+++ b/src/robot_dart/gui/magnum/gs/camera.cpp
@@ -226,14 +226,16 @@ namespace robot_dart {
                         close(_video_fd[0]); // we close the input on this side
                     }
                     else { // ffmpeg process
+                        args.push_back("-loglevel");
+                        args.push_back("quiet");
                         close(_video_fd[1]); // ffmpeg does not write here
                         dup2(_video_fd[0], STDIN_FILENO); // ffmpeg will read the fd[0] as stdin
                         char** argv = (char**)calloc(args.size() + 1, sizeof(char*)); // we need the 0 at the end
-                        for (int i = 0; i < args.size(); ++i)
-                            argv[i] = (char*)args[i].c_str();
+                        argv[0] = (char*)"ffmpeg";
+                        for (size_t i = 0; i < args.size(); ++i)
+                            argv[i + 1] = (char*)args[i].c_str();
                         execvp("ffmpeg", argv);
                     }
-                    // ROBOT_DART_WARNING(true, "Boost version does not support 'boost.process'. Cannot record video!");
 #endif
                 }
 

--- a/src/robot_dart/gui/magnum/gs/camera.cpp
+++ b/src/robot_dart/gui/magnum/gs/camera.cpp
@@ -188,6 +188,7 @@ namespace robot_dart {
                 void Camera::record_video(const std::string& video_fname, int fps)
                 {
                     // we use boost process: https://www.boost.org/doc/libs/1_73_0/doc/html/boost_process/tutorial.html
+#ifdef ROBOT_DART_HAS_BOOST_PROCESS
                     namespace bp = boost::process;
                     // search for ffmpeg
                     boost::filesystem::path ffmpeg = bp::search_path("ffmpeg");
@@ -195,6 +196,7 @@ namespace robot_dart {
                         ROBOT_DART_WARNING(ffmpeg.empty(), "ffmpeg not found in the PATH. RobotDART will not be able to record videos!");
                         return;
                     }
+#endif
                     // std::cout << "Found FFMPEG:" << ffmpeg << std::endl;
                     _recording_video = true;
                     // list our options

--- a/src/robot_dart/gui/magnum/gs/camera.hpp
+++ b/src/robot_dart/gui/magnum/gs/camera.hpp
@@ -90,6 +90,9 @@ namespace robot_dart {
                     // pipe to write a video
                     boost::process::opstream _video_pipe;
                     boost::process::child _ffmpeg_process;
+#else
+                    pid_t _video_pid = 0;
+                    int _video_fd[2];
 #endif
                 };
             } // namespace gs

--- a/src/robot_dart/gui/magnum/gs/camera.hpp
+++ b/src/robot_dart/gui/magnum/gs/camera.hpp
@@ -9,8 +9,6 @@
 #if ((BOOST_VERSION / 100000) > 1) || ((BOOST_VERSION / 100000) == 1 && ((BOOST_VERSION / 100 % 1000) >= 64))
 #include <boost/process.hpp> // for launching ffmpeg
 #define ROBOT_DART_HAS_BOOST_PROCESS
-#else
-#warning Boost.process is not supported. Will not be able to record videos.
 #endif
 
 #include <Corrade/Containers/Optional.h>


### PR DESCRIPTION
I implemented it in the "good old way" because the unbuntu that is on the official Talos dev dockers/PC (16.x) does not have the right boost version.

We might remove this in the future once everybody has a a recent boost.