### PR TITLE
Robot reset

### DIFF
--- a/src/python/robot.cpp
+++ b/src/python/robot.cpp
@@ -61,6 +61,9 @@ namespace robot_dart {
                 .def("free", &Robot::free)
 
                 .def("reset", &Robot::reset)
+                .def("clear_external_forces", &Robot::clear_external_forces)
+                .def("clear_internal_forces", &Robot::clear_internal_forces)
+                .def("reset_commands", &Robot::reset_commands)
 
                 .def("set_actuator_types", &Robot::set_actuator_types,
                     py::arg("type"),
@@ -236,8 +239,6 @@ namespace robot_dart {
                     py::arg("body_index"),
                     py::arg("torque"),
                     py::arg("local") = false)
-
-                .def("clear_external_forces", &Robot::clear_external_forces)
 
                 .def("external_forces", (Eigen::Vector6d(Robot::*)(const std::string& body_name) const) & Robot::external_forces)
                 .def("external_forces", (Eigen::Vector6d(Robot::*)(size_t body_index) const) & Robot::external_forces)

--- a/src/robot_dart/robot.cpp
+++ b/src/robot_dart/robot.cpp
@@ -489,11 +489,21 @@ namespace robot_dart {
         _skeleton->resetPositions();
         _skeleton->resetVelocities();
         _skeleton->resetAccelerations();
+
+        clear_internal_forces();
+        reset_commands();
+        clear_external_forces();
+    }
+
+    void Robot::clear_external_forces() { _skeleton->clearExternalForces(); }
+
+    void Robot::clear_internal_forces()
+    {
         _skeleton->clearInternalForces();
         _skeleton->clearConstraintImpulses();
-        _skeleton->resetCommands();
-        this->clear_external_forces();
     }
+
+    void Robot::reset_commands() { _skeleton->resetCommands(); }
 
     void Robot::set_actuator_types(const std::string& type, const std::vector<std::string>& joint_names, bool override_mimic, bool override_base)
     {
@@ -1006,8 +1016,6 @@ namespace robot_dart {
 
         bd->addExtTorque(torque, local);
     }
-
-    void Robot::clear_external_forces() { _skeleton->clearExternalForces(); }
 
     Eigen::Vector6d Robot::external_forces(const std::string& body_name) const
     {
@@ -1722,8 +1730,10 @@ namespace robot_dart {
         body->setInertia(inertia);
 
         // Put the body into position
+        auto robot = std::make_shared<Robot>(box_skel, box_name);
+
         if (type == "free") // free floating
-            box_skel->setPositions(pose);
+            robot->set_positions(pose);
         else // fixed
         {
             Eigen::Isometry3d T;
@@ -1732,7 +1742,7 @@ namespace robot_dart {
             body->getParentJoint()->setTransformFromParentBodyNode(T);
         }
 
-        return std::make_shared<Robot>(box_skel, box_name);
+        return robot;
     }
 
     std::shared_ptr<Robot> Robot::create_ellipsoid(const Eigen::Vector3d& dims,
@@ -1763,9 +1773,11 @@ namespace robot_dart {
         inertia.setMoment(ellipsoid->computeInertia(mass));
         body->setInertia(inertia);
 
+        auto robot = std::make_shared<Robot>(ellipsoid_skel, ellipsoid_name);
+
         // Put the body into position
         if (type == "free") // free floating
-            ellipsoid_skel->setPositions(pose);
+            robot->set_positions(pose);
         else // fixed
         {
             Eigen::Isometry3d T;
@@ -1774,6 +1786,6 @@ namespace robot_dart {
             body->getParentJoint()->setTransformFromParentBodyNode(T);
         }
 
-        return std::make_shared<Robot>(ellipsoid_skel, ellipsoid_name);
+        return robot;
     }
 } // namespace robot_dart

--- a/src/robot_dart/robot.cpp
+++ b/src/robot_dart/robot.cpp
@@ -288,6 +288,7 @@ namespace robot_dart {
         ROBOT_DART_EXCEPTION_INTERNAL_ASSERT(_skeleton != nullptr);
         _skeleton->setName(robot_name);
         _set_damages(damages);
+        reset();
     }
 
     std::shared_ptr<Robot> Robot::clone() const
@@ -488,6 +489,9 @@ namespace robot_dart {
         _skeleton->resetPositions();
         _skeleton->resetVelocities();
         _skeleton->resetAccelerations();
+        _skeleton->clearInternalForces();
+        _skeleton->clearConstraintImpulses();
+        _skeleton->resetCommands();
         this->clear_external_forces();
     }
 

--- a/src/robot_dart/robot.hpp
+++ b/src/robot_dart/robot.hpp
@@ -65,6 +65,10 @@ namespace robot_dart {
 
         void reset();
 
+        void clear_external_forces();
+        void clear_internal_forces();
+        void reset_commands();
+
         // actuator type can be: torque, servo, velocity, passive, locked, mimic (only for completeness, use set_mimic to use this)
         // Be careful that actuator types are per joint and not per DoF
         void set_actuator_types(const std::string& type, const std::vector<std::string>& joint_names = {}, bool override_mimic = false, bool override_base = false);
@@ -154,8 +158,6 @@ namespace robot_dart {
         void set_external_torque(size_t body_index, const Eigen::Vector3d& torque, bool local = false);
         void add_external_torque(const std::string& body_name, const Eigen::Vector3d& torque, bool local = false);
         void add_external_torque(size_t body_index, const Eigen::Vector3d& torque, bool local = false);
-
-        void clear_external_forces();
 
         Eigen::Vector6d external_forces(const std::string& body_name) const;
         Eigen::Vector6d external_forces(size_t body_index) const;


### PR DESCRIPTION
This PR makes the `robot.reset()` function better and makes sure that when we clone or initialize with a skeleton, we reset everything to get a clean robot structure.