### PR TITLE
Remove the link to the dependencies (esp. assimp)

### DIFF
--- a/waf_tools/dart.py
+++ b/waf_tools/dart.py
@@ -40,19 +40,6 @@ def check_dart(conf, *k, **kw):
             includes_check = [os.environ['RESIBOTS_DIR'] + '/include'] + includes_check
             libs_check = [os.environ['RESIBOTS_DIR'] + '/lib'] + libs_check
 
-    # DART requires assimp library
-    assimp_include = []
-    assimp_lib = []
-    assimp_check = ['/usr/local/include', '/usr/include']
-    assimp_libs = ['/usr/local/lib', '/usr/local/lib64', '/usr/lib', '/usr/lib64', '/usr/lib/x86_64-linux-gnu/']
-    assimp_found = False
-    try:
-        assimp_include = get_directory('assimp/scene.h', assimp_check)
-        assimp_lib = [get_directory('libassimp.' + suffix, assimp_libs)]
-        assimp_found = True
-    except:
-        assimp_found = False
-
     # DART has some optional Bullet features
     bullet_check = ['/usr/local/include/bullet', '/usr/include/bullet']
     bullet_libs = ['/usr/local/lib', '/usr/local/lib64', '/usr/lib', '/usr/lib64', '/usr/lib/x86_64-linux-gnu/']
@@ -182,8 +169,6 @@ def check_dart(conf, *k, **kw):
         conf.end_msg(str(dart_major)+'.'+str(dart_minor)+'.'+str(dart_patch)+' in '+dart_include[0])
 
         more_includes = []
-        if assimp_found:
-            more_includes += assimp_include
 
         conf.start_msg('Checking for DART libs (including io/urdf)')
         dart_lib = []
@@ -197,13 +182,7 @@ def check_dart(conf, *k, **kw):
         if len(dart_cxx_flags) > 0:
             conf.env.CXXFLAGS_DART = [dart_cxx_flags]
         conf.end_msg(conf.env.LIB_DART)
-        conf.start_msg('DART: Checking for Assimp')
-        if assimp_found:
-            conf.end_msg(assimp_include)
-            conf.env.LIBPATH_DART = conf.env.LIBPATH_DART + assimp_lib
-            conf.env.LIB_DART.append('assimp')
-        else:
-            conf.end_msg('Not found - Your programs may not compile', 'RED')
+      
 
         if dart_have_bullet:
             conf.start_msg('DART: Checking for Bullet Collision libs')

--- a/waf_tools/magnum_plugins.py
+++ b/waf_tools/magnum_plugins.py
@@ -168,9 +168,6 @@ def check_magnum_plugins(conf, *k, **kw):
 
     for component in requested_components:
         conf.start_msg('Checking for ' + component + ' Magnum Plugin')
-        # magnum_plugins_component_includes[component] = copy.deepcopy(conf.env['INCLUDES_%s_Magnum' % magnum_var])
-        # magnum_plugins_component_libpaths[component] = copy.deepcopy(conf.env['LIBPATH_%s_Magnum' % magnum_var])
-        # magnum_plugins_component_libs[component] = copy.deepcopy(conf.env['LIB_%s_Magnum' % magnum_var])
         magnum_plugins_component_includes[component] = []
         magnum_plugins_component_libpaths[component] = []
         magnum_plugins_component_libs[component] = []
@@ -189,14 +186,6 @@ def check_magnum_plugins(conf, *k, **kw):
                     conf.fatal(msg)
                 Logs.pprint('RED', msg)
                 return
-            # add includes/paths/libs
-            # magnum_plugins_includes = magnum_plugins_includes + conf.env['INCLUDES_%s_Audio' % magnum_var]
-            # magnum_plugins_libpaths = magnum_plugins_libpaths + conf.env['LIBPATH_%s_Audio' % magnum_var]
-            # magnum_plugins_libs = magnum_plugins_libs + conf.env['LIB_%s_Audio' % magnum_var]
-
-            # magnum_plugins_component_includes[component] = magnum_plugins_component_includes[component] + conf.env['INCLUDES_%s_Audio' % magnum_var]
-            # magnum_plugins_component_libpaths[component] = magnum_plugins_component_libpaths[component] + conf.env['LIBPATH_%s_Audio' % magnum_var]
-            # magnum_plugins_component_libs[component] = magnum_plugins_component_libs[component] + conf.env['LIB_%s_Audio' % magnum_var]
         elif re.match(pat_importer, component):
             lib_path_suffix = 'importers'
         elif re.match(pat_font, component):
@@ -214,15 +203,7 @@ def check_magnum_plugins(conf, *k, **kw):
                     conf.fatal(msg)
                 Logs.pprint('RED', msg)
                 return
-            # add includes/paths/libs
-            # magnum_plugins_includes = magnum_plugins_includes + conf.env['INCLUDES_%s_Text' % magnum_var]
-            # magnum_plugins_libpaths = magnum_plugins_libpaths + conf.env['LIBPATH_%s_Text' % magnum_var]
-            # magnum_plugins_libs = magnum_plugins_libs + conf.env['LIB_%s_Text' % magnum_var]
-
-            # magnum_plugins_component_includes[component] = magnum_plugins_component_includes[component] + conf.env['INCLUDES_%s_Text' % magnum_var]
-            # magnum_plugins_component_libpaths[component] = magnum_plugins_component_libpaths[component] + conf.env['LIBPATH_%s_Text' % magnum_var]
-            # magnum_plugins_component_libs[component] = magnum_plugins_component_libs[component] + conf.env['LIB_%s_Text' % magnum_var]
-
+         
         if lib_path_suffix != '':
             lib_path_suffix = lib_path_suffix + '/'
 
@@ -233,12 +214,8 @@ def check_magnum_plugins(conf, *k, **kw):
             # we need the full lib_dir in order to be able to link to the plugins
             # or not? because they are loaded dynamically
             lib_dir = get_directory('magnum/'+lib_path_suffix+lib+'.'+modules_suffix, libs_check, True)
-            # magnum_plugins_libs.append(lib)
-            # magnum_plugins_libpaths = magnum_plugins_libpaths + [lib_dir]
-
+           
             magnum_plugins_component_includes[component] = magnum_plugins_component_includes[component] + [include_dir]
-            # magnum_plugins_component_libpaths[component] = magnum_plugins_component_libpaths[component] + [lib_dir]
-            # magnum_plugins_component_libs[component].append(lib)
         except:
             if required:
                 conf.fatal('Not found')
@@ -247,107 +224,6 @@ def check_magnum_plugins(conf, *k, **kw):
             continue
         conf.end_msg(include_dir)
 
-        # extra dependencies
-        if component == 'AssimpImporter':
-            # AssimpImporter requires Assimp
-            conf.start_msg(component + ': Checking for Assimp')
-            try:
-                assimp_inc = get_directory('assimp/anim.h', includes_check)
-
-                magnum_plugins_includes = magnum_plugins_includes + [assimp_inc]
-                magnum_plugins_component_includes[component] = magnum_plugins_component_includes[component] + [assimp_inc]
-
-                lib_dir = get_directory('libassimp.'+suffix, libs_check)
-                magnum_plugins_libpaths = magnum_plugins_libpaths + [lib_dir]
-                magnum_plugins_libs.append('assimp')
-
-                magnum_plugins_component_libpaths[component] = magnum_plugins_component_libpaths[component] + [lib_dir]
-                magnum_plugins_component_libs[component].append('assimp')
-            except:
-                if required:
-                    conf.fatal('Not found')
-                conf.end_msg('Not found', 'RED')
-                # if optional, continue?
-                continue
-            conf.end_msg(assimp_inc)
-        elif component == 'DevIlImageImporter':
-            # DevIlImageImporter requires DevIl
-            msg = component + ' is not supported with WAF'
-            if required:
-                conf.fatal(msg)
-            conf.end_msg(msg, 'RED')
-        elif component == 'FreeTypeFont':
-            # FreeTypeFont requires FreeType2?
-            conf.start_msg(component + ': Checking for FreeType')
-            try:
-                freetype_inc = get_directory('freetype/ft2build.h', includes_check, True)
-
-                magnum_plugins_includes = magnum_plugins_includes + [freetype_inc]
-                magnum_plugins_component_includes[component] = magnum_plugins_component_includes[component] + [freetype_inc]
-
-                lib_dir = get_directory('libfreetype.'+suffix, libs_check)
-                magnum_plugins_libpaths = magnum_plugins_libpaths + [lib_dir]
-                magnum_plugins_libs.append('freetype')
-
-                magnum_plugins_component_libpaths[component] = magnum_plugins_component_libpaths[component] + [lib_dir]
-                magnum_plugins_component_libs[component].append('freetype')
-            except:
-                if required:
-                    conf.fatal('Not found')
-                conf.end_msg('Not found', 'RED')
-                # if optional, continue?
-                continue
-            conf.end_msg(freetype_inc)
-        elif component == 'HarfBuzzFont':
-            # HarfBuzzFont requires FreeType and HarfBuzz
-            msg = component + ' is not supported with WAF'
-            if required:
-                conf.fatal(msg)
-            conf.end_msg(msg, 'RED')
-        elif component == 'JpegImporter':
-            # JpegImporter requires JPEG
-            conf.start_msg(component + ': Checking for JPEG')
-            try:
-                jpeg_inc = get_directory('jpeglib.h', includes_check)
-
-                magnum_plugins_includes = magnum_plugins_includes + [jpeg_inc]
-                magnum_plugins_component_includes[component] = magnum_plugins_component_includes[component] + [jpeg_inc]
-
-                lib_dir = get_directory('libjpeg.'+suffix, libs_check)
-                magnum_plugins_libpaths = magnum_plugins_libpaths + [lib_dir]
-                magnum_plugins_libs.append('jpeg')
-
-                magnum_plugins_component_libpaths[component] = magnum_plugins_component_libpaths[component] + [lib_dir]
-                magnum_plugins_component_libs[component].append('jpeg')
-            except:
-                if required:
-                    conf.fatal('Not found')
-                conf.end_msg('Not found', 'RED')
-                # if optional, continue?
-                continue
-            conf.end_msg(jpeg_inc)
-        elif component == 'PngImageConverter' or component == 'PngImporter':
-            # PngImageConverter and PngImporter require PNG
-            conf.start_msg(component + ': Checking for PNG')
-            try:
-                png_inc = get_directory('png.h', includes_check)
-
-                magnum_plugins_includes = magnum_plugins_includes + [png_inc]
-                magnum_plugins_component_includes[component] = magnum_plugins_component_includes[component] + [png_inc]
-
-                lib_dir = get_directory('libpng.'+suffix, libs_check)
-                magnum_plugins_libpaths = magnum_plugins_libpaths + [lib_dir]
-                magnum_plugins_libs.append('png')
-
-                magnum_plugins_component_libpaths[component] = magnum_plugins_component_libpaths[component] + [lib_dir]
-                magnum_plugins_component_libs[component].append('png')
-            except:
-                if required:
-                    conf.fatal('Not found')
-                conf.end_msg('Not found', 'RED')
-                # if optional, continue?
-                continue
-            conf.end_msg(png_inc)
 
     if len(magnum_plugins_libs) > 0:
         conf.start_msg(magnum_plugins_var + ' libs:')
@@ -365,10 +241,6 @@ def check_magnum_plugins(conf, *k, **kw):
 
     # set component libs
     for component in requested_components:
-        # for lib in magnum_plugins_dependencies[component]:
-        #     magnum_plugins_component_includes[component] = magnum_plugins_component_includes[component] + magnum_plugins_component_includes[lib]
-        #     magnum_plugins_component_libpaths[component] = magnum_plugins_component_libpaths[component] + magnum_plugins_component_libpaths[lib]
-        #     magnum_plugins_component_libs[component] = magnum_plugins_component_libs[component] + magnum_plugins_component_libs[lib]
 
         conf.env['INCLUDES_%s_%s' % (magnum_plugins_var, component)] = list(set(magnum_plugins_component_includes[component]))
         conf.env['LIBPATH_%s_%s' % (magnum_plugins_var, component)] = list(set(magnum_plugins_component_libpaths[component]))


### PR DESCRIPTION
It seems that linking to the dependencies is not required with modern OS/linkers (that is, we link with Dart and Dart links with assimp on its own).

If we do it, this easily leads to inconsistencies if we do not find the same version (e.g dart uses assimp5 and we find assimp3). Also, this is useless code to maintain :)