### PR TITLE
Make text rendering a parameter

### DIFF
--- a/src/examples/cameras.cpp
+++ b/src/examples/cameras.cpp
@@ -48,7 +48,7 @@ int main()
     robot_dart::RobotDARTSimu simu(0.001);
 
     // Magnum graphics
-    robot_dart::gui::magnum::GraphicsConfiguration configuration;
+    robot_dart::gui::magnum::GraphicsConfiguration configuration = robot_dart::gui::magnum::Graphics::default_configuration();
     configuration.width = 1024;
     configuration.height = 768;
     auto graphics = std::make_shared<robot_dart::gui::magnum::BaseGraphics<MyApp>>(configuration);

--- a/src/examples/magnum_contexts.cpp
+++ b/src/examples/magnum_contexts.cpp
@@ -51,7 +51,7 @@ int main()
             controller->set_pd(300., 50.);
 
             // Magnum graphics
-            robot_dart::gui::magnum::GraphicsConfiguration configuration;
+            robot_dart::gui::magnum::GraphicsConfiguration configuration = robot_dart::gui::magnum::WindowlessGraphics::default_configuration();
             configuration.width = 1024;
             configuration.height = 768;
             auto graphics = std::make_shared<robot_dart::gui::magnum::WindowlessGraphics>(configuration);

--- a/src/python/gui.cpp
+++ b/src/python/gui.cpp
@@ -86,7 +86,7 @@ namespace robot_dart {
                 .def_readwrite("data", &gui::GrayscaleImage::data);
 
             py::class_<GraphicsConfiguration>(sm, "GraphicsConfiguration")
-                .def(py::init<size_t, size_t, const std::string&, bool, bool, size_t, size_t, double, bool, bool, const Eigen::Vector4d&>(),
+                .def(py::init<size_t, size_t, const std::string&, bool, bool, size_t, size_t, double, bool, bool, bool, const Eigen::Vector4d&>(),
                     py::arg("width") = 640,
                     py::arg("height") = 480,
                     py::arg("title") = "DART",
@@ -97,6 +97,7 @@ namespace robot_dart {
                     py::arg("specular_strength") = 0.25,
                     py::arg("draw_main_camera") = true,
                     py::arg("draw_debug") = true,
+                    py::arg("draw_text") = true,
                     py::arg("bg_color") = Eigen::Vector4d(0.0, 0.0, 0.0, 1.0))
 
                 .def_readwrite("width", &GraphicsConfiguration::width)
@@ -112,6 +113,7 @@ namespace robot_dart {
 
                 .def_readwrite("draw_main_camera", &GraphicsConfiguration::draw_main_camera)
                 .def_readwrite("draw_debug", &GraphicsConfiguration::draw_debug)
+                .def_readwrite("draw_text", &GraphicsConfiguration::draw_text)
 
                 .def_readwrite("bg_color", &GraphicsConfiguration::bg_color);
 
@@ -124,7 +126,7 @@ namespace robot_dart {
             // Graphics class
             py::class_<Graphics, BaseWindowedGraphics, std::shared_ptr<Graphics>>(sm, "Graphics")
                 .def(py::init<const GraphicsConfiguration&>(),
-                    py::arg("configuration") = GraphicsConfiguration())
+                    py::arg("configuration") = Graphics::default_configuration())
 
                 .def("done", &Graphics::done)
                 .def("refresh", &Graphics::refresh)
@@ -165,12 +167,14 @@ namespace robot_dart {
 
                 .def("camera", (Camera & (Graphics::*)()) & Graphics::camera, py::return_value_policy::reference)
 
-                .def("magnum_app", (gui::magnum::BaseApplication * (Graphics::*)()) & Graphics::magnum_app, py::return_value_policy::reference);
+                .def("magnum_app", (gui::magnum::BaseApplication * (Graphics::*)()) & Graphics::magnum_app, py::return_value_policy::reference)
+
+                .def_static("default_configuration", &Graphics::default_configuration);
 
             // WindowlessGraphics class
             py::class_<WindowlessGraphics, BaseWindowlessGraphics, std::shared_ptr<WindowlessGraphics>>(sm, "WindowlessGraphics")
                 .def(py::init<const GraphicsConfiguration&>(),
-                    py::arg("configuration") = GraphicsConfiguration())
+                    py::arg("configuration") = WindowlessGraphics::default_configuration())
 
                 .def("done", &WindowlessGraphics::done)
                 .def("refresh", &WindowlessGraphics::refresh)
@@ -208,7 +212,9 @@ namespace robot_dart {
 
                 .def("camera", (Camera & (WindowlessGraphics::*)()) & WindowlessGraphics::camera, py::return_value_policy::reference)
 
-                .def("magnum_app", (gui::magnum::BaseApplication * (WindowlessGraphics::*)()) & WindowlessGraphics::magnum_app, py::return_value_policy::reference);
+                .def("magnum_app", (gui::magnum::BaseApplication * (WindowlessGraphics::*)()) & WindowlessGraphics::magnum_app, py::return_value_policy::reference)
+
+                .def_static("default_configuration", &WindowlessGraphics::default_configuration);
 
             sm.def(
                 "run_with_gl_context", +[](const std::function<void()>& func, size_t wait_ms) {

--- a/src/robot_dart/gui/magnum/base_application.cpp
+++ b/src/robot_dart/gui/magnum/base_application.cpp
@@ -169,26 +169,28 @@ namespace robot_dart {
                     .setIndexBuffer(std::move(axis_indices), 0, compressed.second);
 
                 /* Initialize text visualization */
-                Corrade::Utility::Resource rs("RobotDARTShaders");
-                _font = _font_manager.loadAndInstantiate("TrueTypeFont");
-                if (_font) {
-                    _font->openData(rs.getRaw("SourceSansPro-Regular.ttf"), 180.0f);
+                if (_configuration.draw_debug && _configuration.draw_text) { // only if we ask for it
+                    _font = _font_manager.loadAndInstantiate("TrueTypeFont");
+                    if (_font) {
+                        Corrade::Utility::Resource rs("RobotDARTShaders");
+                        _font->openData(rs.getRaw("SourceSansPro-Regular.ttf"), 180.0f);
 
-                    /* Glyphs we need to render everything */
-                    /* Latin characters for now only */
-                    _glyph_cache.reset(new Magnum::Text::DistanceFieldGlyphCache{Magnum::Vector2i{2048}, Magnum::Vector2i{512}, 22});
-                    _font->fillGlyphCache(*_glyph_cache,
-                        "abcdefghijklmnopqrstuvwxyz"
-                        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                        "0123456789:-+*,.!° /|[]()_");
+                        /* Glyphs we need to render everything */
+                        /* Latin characters for now only */
+                        _glyph_cache.reset(new Magnum::Text::DistanceFieldGlyphCache{Magnum::Vector2i{2048}, Magnum::Vector2i{512}, 22});
+                        _font->fillGlyphCache(*_glyph_cache,
+                            "abcdefghijklmnopqrstuvwxyz"
+                            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                            "0123456789:-+*,.!° /|[]()_");
 
-                    /* Initialize buffers for text */
-                    _text_vertices.reset(new Magnum::GL::Buffer);
-                    _text_indices.reset(new Magnum::GL::Buffer);
+                        /* Initialize buffers for text */
+                        _text_vertices.reset(new Magnum::GL::Buffer);
+                        _text_indices.reset(new Magnum::GL::Buffer);
 
-                    /* Initialize text shader */
-                    _text_shader.reset(new Magnum::Shaders::DistanceFieldVector2D);
-                    _text_shader->bindVectorTexture(_glyph_cache->texture());
+                        /* Initialize text shader */
+                        _text_shader.reset(new Magnum::Shaders::DistanceFieldVector2D);
+                        _text_shader->bindVectorTexture(_glyph_cache->texture());
+                    }
                 }
             }
 

--- a/src/robot_dart/gui/magnum/base_application.hpp
+++ b/src/robot_dart/gui/magnum/base_application.hpp
@@ -107,6 +107,7 @@ namespace robot_dart {
                 // These options are only for the main camera
                 bool draw_main_camera = true;
                 bool draw_debug = true;
+                bool draw_text = true;
 
                 // Background (default = black)
                 Eigen::Vector4d bg_color{0.0, 0.0, 0.0, 1.0};

--- a/src/robot_dart/gui/magnum/graphics.cpp
+++ b/src/robot_dart/gui/magnum/graphics.cpp
@@ -12,6 +12,11 @@ namespace robot_dart {
                 simu->enable_text_panel(true);
                 simu->enable_status_bar(true);
             }
+
+            GraphicsConfiguration Graphics::default_configuration()
+            {
+                return GraphicsConfiguration();
+            }
         } // namespace magnum
     } // namespace gui
 } // namespace robot_dart

--- a/src/robot_dart/gui/magnum/graphics.hpp
+++ b/src/robot_dart/gui/magnum/graphics.hpp
@@ -8,10 +8,12 @@ namespace robot_dart {
         namespace magnum {
             class Graphics : public BaseGraphics<GlfwApplication> {
             public:
-                Graphics(const GraphicsConfiguration& configuration = GraphicsConfiguration()) : BaseGraphics<GlfwApplication>(configuration) {}
+                Graphics(const GraphicsConfiguration& configuration = default_configuration()) : BaseGraphics<GlfwApplication>(configuration) {}
                 ~Graphics() {}
 
                 void set_simu(RobotDARTSimu* simu) override;
+
+                static GraphicsConfiguration default_configuration();
             };
         } // namespace magnum
     } // namespace gui

--- a/src/robot_dart/gui/magnum/windowless_graphics.cpp
+++ b/src/robot_dart/gui/magnum/windowless_graphics.cpp
@@ -12,6 +12,16 @@ namespace robot_dart {
                 simu->enable_text_panel(false);
                 simu->enable_status_bar(false);
             }
+
+            GraphicsConfiguration WindowlessGraphics::default_configuration()
+            {
+                GraphicsConfiguration config;
+                // by default we do not draw text in windowless mode
+                config.draw_debug = false;
+                config.draw_text = false;
+
+                return config;
+            }
         } // namespace magnum
     } // namespace gui
 } // namespace robot_dart

--- a/src/robot_dart/gui/magnum/windowless_graphics.hpp
+++ b/src/robot_dart/gui/magnum/windowless_graphics.hpp
@@ -9,10 +9,12 @@ namespace robot_dart {
         namespace magnum {
             class WindowlessGraphics : public BaseGraphics<WindowlessGLApplication> {
             public:
-                WindowlessGraphics(const GraphicsConfiguration& configuration = GraphicsConfiguration()) : BaseGraphics<WindowlessGLApplication>(configuration) {}
+                WindowlessGraphics(const GraphicsConfiguration& configuration = default_configuration()) : BaseGraphics<WindowlessGLApplication>(configuration) {}
                 ~WindowlessGraphics() {}
 
                 void set_simu(RobotDARTSimu* simu) override;
+
+                static GraphicsConfiguration default_configuration();
             };
         } // namespace magnum
     } // namespace gui


### PR DESCRIPTION
Now we can easily turn on/off text rendering. By default, no text is rendered in windowless graphics mode. This solves #120 ...