### PR TITLE
Updates installation instructions.

### DIFF
--- a/ci/install_dart_latest.sh
+++ b/ci/install_dart_latest.sh
@@ -11,6 +11,7 @@ fi
 
 git clone git://github.com/dartsim/dart.git
 cd dart
+git checkout v6.10.1
 mkdir build
 cd build
 if [ "$PYTHON_TESTS" = "ON" ]; then
@@ -21,7 +22,6 @@ fi
 make -j4
 sudo make install
 if [ "$PYTHON_TESTS" = "ON" ]; then
-    make dartpy -j4
     sudo make install-dartpy
 fi
 sudo ldconfig

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -109,7 +109,7 @@ cd /path/to/tmp/folder
 git clone https://github.com/mosra/corrade.git
 cd corrade
 mkdir build && cd build
-cmake ..
+cmake -DCMAKE_BUILD_TYPE=Release ..
 make -j
 sudo make install
 
@@ -119,9 +119,9 @@ git clone https://github.com/mosra/magnum.git
 cd magnum
 mkdir build && cd build
 # Ubuntu
-cmake -DWITH_AUDIO=ON -DWITH_DEBUGTOOLS=ON -DWITH_GL=ON -DWITH_MESHTOOLS=ON -DWITH_PRIMITIVES=ON -DWITH_SCENEGRAPH=ON -DWITH_SHADERS=ON -DWITH_TEXT=ON -DWITH_TEXTURETOOLS=ON -DWITH_TRADE=ON -DWITH_GLFWAPPLICATION=ON -DWITH_WINDOWLESSGLXAPPLICATION=ON -DWITH_OPENGLTESTER=ON -DWITH_ANYAUDIOIMPORTER=ON -DWITH_ANYIMAGECONVERTER=ON -DWITH_ANYIMAGEIMPORTER=ON -DWITH_ANYSCENEIMPORTER=ON -DWITH_MAGNUMFONT=ON -DWITH_OBJIMPORTER=ON -DWITH_TGAIMPORTER=ON -DWITH_WAVAUDIOIMPORTER=ON .. # this will enable almost all features of Magnum that are not necessarily needed for robot_dart (please refer to the documentation of Magnum for more details on selecting only the ones that you need)
+cmake -DCMAKE_BUILD_TYPE=Release -DWITH_AUDIO=ON -DWITH_DEBUGTOOLS=ON -DWITH_GL=ON -DWITH_MESHTOOLS=ON -DWITH_PRIMITIVES=ON -DWITH_SCENEGRAPH=ON -DWITH_SHADERS=ON -DWITH_TEXT=ON -DWITH_TEXTURETOOLS=ON -DWITH_TRADE=ON -DWITH_GLFWAPPLICATION=ON -DWITH_WINDOWLESSGLXAPPLICATION=ON -DWITH_OPENGLTESTER=ON -DWITH_ANYAUDIOIMPORTER=ON -DWITH_ANYIMAGECONVERTER=ON -DWITH_ANYIMAGEIMPORTER=ON -DWITH_ANYSCENEIMPORTER=ON -DWITH_MAGNUMFONT=ON -DWITH_OBJIMPORTER=ON -DWITH_TGAIMPORTER=ON -DWITH_WAVAUDIOIMPORTER=ON .. # this will enable almost all features of Magnum that are not necessarily needed for robot_dart (please refer to the documentation of Magnum for more details on selecting only the ones that you need)
 # Mac OSX
-cmake -DWITH_AUDIO=ON -DWITH_DEBUGTOOLS=ON -DWITH_GL=ON -DWITH_MESHTOOLS=ON -DWITH_PRIMITIVES=ON -DWITH_SCENEGRAPH=ON -DWITH_SHADERS=ON -DWITH_TEXT=ON -DWITH_TEXTURETOOLS=ON -DWITH_TRADE=ON -DWITH_GLFWAPPLICATION=ON -DWITH_WINDOWLESSCGLAPPLICATION=ON -DWITH_OPENGLTESTER=ON -DWITH_ANYAUDIOIMPORTER=ON -DWITH_ANYIMAGECONVERTER=ON -DWITH_ANYIMAGEIMPORTER=ON -DWITH_ANYSCENEIMPORTER=ON -DWITH_MAGNUMFONT=ON -DWITH_OBJIMPORTER=ON -DWITH_TGAIMPORTER=ON -DWITH_WAVAUDIOIMPORTER=ON .. # this will enable almost all features of Magnum that are not necessarily needed for robot_dart (please refer to the documentation of Magnum for more details on selecting only the ones that you need)
+cmake -DCMAKE_BUILD_TYPE=Release -DWITH_AUDIO=ON -DWITH_DEBUGTOOLS=ON -DWITH_GL=ON -DWITH_MESHTOOLS=ON -DWITH_PRIMITIVES=ON -DWITH_SCENEGRAPH=ON -DWITH_SHADERS=ON -DWITH_TEXT=ON -DWITH_TEXTURETOOLS=ON -DWITH_TRADE=ON -DWITH_GLFWAPPLICATION=ON -DWITH_WINDOWLESSCGLAPPLICATION=ON -DWITH_OPENGLTESTER=ON -DWITH_ANYAUDIOIMPORTER=ON -DWITH_ANYIMAGECONVERTER=ON -DWITH_ANYIMAGEIMPORTER=ON -DWITH_ANYSCENEIMPORTER=ON -DWITH_MAGNUMFONT=ON -DWITH_OBJIMPORTER=ON -DWITH_TGAIMPORTER=ON -DWITH_WAVAUDIOIMPORTER=ON .. # this will enable almost all features of Magnum that are not necessarily needed for robot_dart (please refer to the documentation of Magnum for more details on selecting only the ones that you need)
 make -j
 sudo make install
 
@@ -130,7 +130,7 @@ cd /path/to/tmp/folder
 git clone https://github.com/mosra/magnum-plugins.git
 cd magnum-plugins
 mkdir build && cd build
-cmake -DWITH_ASSIMPIMPORTER=ON -DWITH_DDSIMPORTER=ON -DWITH_JPEGIMPORTER=ON -DWITH_OPENGEXIMPORTER=ON -DWITH_PNGIMPORTER=ON -DWITH_TINYGLTFIMPORTER=ON .. # this will enable quite a few Magnum Plugins that are not necessarily needed for robot_dart (please refer to the documentation of Magnum for more details on selecting only the ones that you need)
+cmake -DCMAKE_BUILD_TYPE=Release -DWITH_ASSIMPIMPORTER=ON -DWITH_DDSIMPORTER=ON -DWITH_JPEGIMPORTER=ON -DWITH_OPENGEXIMPORTER=ON -DWITH_PNGIMPORTER=ON -DWITH_TINYGLTFIMPORTER=ON -DWITH_STBTRUETYPEFONT=ON .. # this will enable quite a few Magnum Plugins that are not necessarily needed for robot_dart (please refer to the documentation of Magnum for more details on selecting only the ones that you need)
 make -j
 sudo make install
 
@@ -139,7 +139,7 @@ cd /path/to/tmp/folder
 git clone https://github.com/mosra/magnum-integration.git
 cd magnum-integration
 mkdir build && cd build
-cmake -DWITH_DART=ON -DWITH_EIGEN=ON ..
+cmake -DCMAKE_BUILD_TYPE=Release -DWITH_DART=ON -DWITH_EIGEN=ON ..
 make -j
 sudo make install
 ```
@@ -152,6 +152,9 @@ The compilation of the library is straight-forward:
 - `cd /path/to/repo/root`
 - `./waf configure`
 - `./waf`
+
+To build the examples, execute this:
+`./waf examples`
 
 Now you can run the examples. For example, to run the arm example you need to type the following: `./build/arm` (or `./build/arm_plain` to run it without graphics).
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -57,11 +57,11 @@ sudo apt-get install liburdfdom-dev liburdfdom-headers-dev
 cd /path/to/tmp/folder
 git clone git://github.com/dartsim/dart.git
 cd dart
-git checkout release-6.9
+git checkout v6.10.1
 
 mkdir build
 cd build
-cmake -DDART_ENABLE_SIMD=ON ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr ..
 make -j4
 sudo make install
 ```
@@ -84,11 +84,11 @@ brew install urdfdom
 cd /path/to/tmp/folder
 git clone git://github.com/dartsim/dart.git
 cd dart
-git checkout release-6.9
+git checkout v6.10.1
 
 mkdir build
 cd build
-cmake -DDART_ENABLE_SIMD=ON ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr ..
 make -j4
 sudo make install
 ```
@@ -182,11 +182,12 @@ For the python bindings of DART, do:
 ```bash
 cd dart
 
-mkdir build_py # we need a different folder
-cd build_py
-cmake -DDART_BUILD_DARTPY=ON -DDART_ENABLE_SIMD=ON ..
+mkdir build
+cd build
+cmake -DDART_BUILD_DARTPY=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr ..
 make -j4
 sudo make install
+sudo make install-dartpy
 ```
 
 Then the compilation of robot_dart is almost identical as before:


### PR DESCRIPTION
 - Default build type of dependencies "release"
This is taken from CI and I argue that it's a good default for most users.
 - Add missing "DWITH_STBTRUETYPEFONT=ON"
This was missing when building magnum plugins and prevented the build of graphical examples.
 - Instruction to build the examples