### PR TITLE
Rotational joints error computed on the manifold

### DIFF
--- a/src/examples/franka.cpp
+++ b/src/examples/franka.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <robot_dart/robot_dart_simu.hpp>
 
-#include <robot_dart/control/pd_control.hpp>
+#include <robot_dart/control/manifold_control.hpp>
 
 #ifdef GRAPHIC
 #include <robot_dart/gui/magnum/graphics.hpp>
@@ -25,8 +25,10 @@ int main()
     // set desired positions
     Eigen::VectorXd ctrl = robot_dart::make_vector({0., M_PI / 4., 0., -M_PI / 4, 0., M_PI / 2., 0., 0.});
 
+    std::vector<int> rotational_joints(ctrl.size(),1);
+
     // add the controller to the robot
-    auto controller = std::make_shared<robot_dart::control::PDControl>(ctrl);
+    auto controller = std::make_shared<robot_dart::control::ManifoldControl>(rotational_joints,ctrl);
     robot->add_controller(controller);
     controller->set_pd(300., 50.);
 

--- a/src/robot_dart/control/manifold_control.cpp
+++ b/src/robot_dart/control/manifold_control.cpp
@@ -1,0 +1,67 @@
+#include <robot_dart/control/manifold_control.hpp>
+#include "robot_dart/robot.hpp"
+#include "robot_dart/utils.hpp"
+
+namespace robot_dart {
+    namespace control {
+   
+        ManifoldControl::ManifoldControl(const std::vector<int>& t_rotational_dofs ):
+          m_rotational_dofs(t_rotational_dofs), PDControl(){}
+
+
+        ManifoldControl::ManifoldControl(
+            const std::vector<int>& t_rotational_dofs,
+            const Eigen::VectorXd& ctrl, bool full_control):
+          m_rotational_dofs(t_rotational_dofs), PDControl(ctrl, full_control){}
+
+
+        ManifoldControl::ManifoldControl(
+            const std::vector<int>& t_rotational_dofs,
+            const Eigen::VectorXd& ctrl,
+            const std::vector<std::string>& controllable_dofs):
+          m_rotational_dofs(t_rotational_dofs), PDControl(ctrl,controllable_dofs ){}
+
+
+        Eigen::VectorXd ManifoldControl::calculate(double)
+        {
+            ROBOT_DART_ASSERT(_control_dof == _ctrl.size(), "ManifoldControl: Controller parameters size is not the same as DOFs of the robot", Eigen::VectorXd::Zero(_control_dof));
+            auto robot = _robot.lock();
+
+            Eigen::VectorXd& target_positions = _ctrl;
+
+            Eigen::VectorXd q = robot->positions(_controllable_dofs);
+            Eigen::VectorXd dq = robot->velocities(_controllable_dofs);
+
+
+            /* Assuming all joints to be rotational e.g. franka robot
+             * error computed on the manifold
+             */
+
+            Eigen::VectorXd error(_ctrl.size() );
+            for(int i=0; i<_ctrl.size(); ++i){
+              if( m_rotational_dofs[i]==1){
+                error(i) = boxMinus( target_positions(i),  q(i) );
+              }
+              else{
+                error(i) =  target_positions(i) - q(i);
+              }
+            }
+
+            Eigen::VectorXd commands = _Kp.array() * error.array() - _Kd.array() * dq.array();
+
+            return commands;
+        }
+
+        double ManifoldControl::boxMinus(const double alfa,  const double beta)
+        {
+          Eigen::Matrix2d R_alfa;
+          Eigen::Matrix2d R_beta;
+          R_alfa << cos( alfa ), -sin( alfa),
+            sin(alfa), cos(alfa);
+          R_beta << cos( beta), -sin(beta),
+            sin(beta), cos(beta);
+          Eigen::Matrix2d R = R_beta.transpose() * R_alfa;
+          return atan2( R(1,0), R(0,0));
+        }
+    }
+}

--- a/src/robot_dart/control/manifold_control.hpp
+++ b/src/robot_dart/control/manifold_control.hpp
@@ -1,0 +1,25 @@
+#include <robot_dart/control/pd_control.hpp>
+
+namespace robot_dart {
+    namespace control {
+
+        class ManifoldControl: public PDControl {
+        public:
+
+            ManifoldControl(const std::vector<int>& t_rotational_dofs );
+            ManifoldControl(
+                const std::vector<int>& t_rotational_dofs,
+                const Eigen::VectorXd& ctrl, bool full_control = false);
+            ManifoldControl(
+                const std::vector<int>& t_rotational_dofs,
+                const Eigen::VectorXd& ctrl,
+                const std::vector<std::string>& controllable_dofs);
+
+            Eigen::VectorXd calculate(double) override;
+
+            double boxMinus(const double alfa,  const double beta);
+        private:
+            const std::vector<int> m_rotational_dofs;
+        };
+    }
+}


### PR DESCRIPTION
Created class that extends PD controller to allow computation of the error of the joints on the manifold if the joints are rotational.
The approach tries to treat the angular quantities on a manifold that ensures that regions of the domain of the angular values that are locally contiguous conceptually are also contiguous numerically.

 For example when I compare two angles alfa = 355 degs and beta = -355 degs
 I want that this result  |alfa -beta| = 20 degs instead of |alfa - beta| = 710 degs.
 Same in rads alfa = 7M_PI/4, beta= 7M_PI/4,|alfa -beta| = M_PI/2  instead of |alfa -beta| = 7*M_PI/2.
This results are obtained by bounding the values of the angular quantities in a closed interval,
 in my case [-M_PI, M_PI].