### PR TITLE
[BitmaskCollisionFilter]: improve with category and collision mask

### DIFF
--- a/src/python/simu.cpp
+++ b/src/python/simu.cpp
@@ -133,16 +133,22 @@ namespace robot_dart {
                 .def("set_collision_detector", &RobotDARTSimu::set_collision_detector)
                 .def("collision_detector", &RobotDARTSimu::collision_detector)
 
-                .def("set_collision_mask", (void (RobotDARTSimu::*)(size_t, uint16_t)) & RobotDARTSimu::set_collision_mask)
-                .def("set_collision_mask", (void (RobotDARTSimu::*)(size_t, const std::string&, uint16_t)) & RobotDARTSimu::set_collision_mask)
-                .def("set_collision_mask", (void (RobotDARTSimu::*)(size_t, size_t, uint16_t)) & RobotDARTSimu::set_collision_mask)
+                .def("set_collision_masks", (void (RobotDARTSimu::*)(size_t, uint32_t, uint32_t)) & RobotDARTSimu::set_collision_masks)
+                .def("set_collision_masks", (void (RobotDARTSimu::*)(size_t, const std::string&, uint32_t, uint32_t)) & RobotDARTSimu::set_collision_masks)
+                .def("set_collision_masks", (void (RobotDARTSimu::*)(size_t, size_t, uint32_t, uint32_t)) & RobotDARTSimu::set_collision_masks)
 
-                .def("collision_mask", (uint16_t(RobotDARTSimu::*)(size_t, const std::string&)) & RobotDARTSimu::collision_mask)
-                .def("collision_mask", (uint16_t(RobotDARTSimu::*)(size_t, size_t)) & RobotDARTSimu::collision_mask)
+                .def("collision_mask", (uint32_t(RobotDARTSimu::*)(size_t, const std::string&)) & RobotDARTSimu::collision_mask)
+                .def("collision_mask", (uint32_t(RobotDARTSimu::*)(size_t, size_t)) & RobotDARTSimu::collision_mask)
 
-                .def("remove_collision_mask", (void (RobotDARTSimu::*)(size_t)) & RobotDARTSimu::remove_collision_mask)
-                .def("remove_collision_mask", (void (RobotDARTSimu::*)(size_t, const std::string&)) & RobotDARTSimu::remove_collision_mask)
-                .def("remove_collision_mask", (void (RobotDARTSimu::*)(size_t, size_t)) & RobotDARTSimu::remove_collision_mask)
+                .def("collision_category", (uint32_t(RobotDARTSimu::*)(size_t, const std::string&)) & RobotDARTSimu::collision_category)
+                .def("collision_category", (uint32_t(RobotDARTSimu::*)(size_t, size_t)) & RobotDARTSimu::collision_category)
+
+                .def("collision_masks", (std::pair<uint32_t, uint32_t>(RobotDARTSimu::*)(size_t, const std::string&)) & RobotDARTSimu::collision_masks)
+                .def("collision_masks", (std::pair<uint32_t, uint32_t>(RobotDARTSimu::*)(size_t, size_t)) & RobotDARTSimu::collision_masks)
+
+                .def("remove_collision_masks", (void (RobotDARTSimu::*)(size_t)) & RobotDARTSimu::remove_collision_masks)
+                .def("remove_collision_masks", (void (RobotDARTSimu::*)(size_t, const std::string&)) & RobotDARTSimu::remove_collision_masks)
+                .def("remove_collision_masks", (void (RobotDARTSimu::*)(size_t, size_t)) & RobotDARTSimu::remove_collision_masks)
 
                 .def("remove_all_collision_masks", &RobotDARTSimu::remove_all_collision_masks);
         }

--- a/src/robot_dart/robot_dart_simu.cpp
+++ b/src/robot_dart/robot_dart_simu.cpp
@@ -23,11 +23,17 @@
 
 namespace robot_dart {
     namespace collision_filter {
-        // This is inspired from ign-physics: https://bitbucket.org/ignitionrobotics/ign-physics/src/0feb6cdf616e38ed919692031b9b9b11e19efddd/dartsim/src/EntityManagementFeatures.cc#lines-38:96
+        // This is inspired from Swift: https://developer.apple.com/documentation/spritekit/skphysicsbody#//apple_ref/occ/instp/SKPhysicsBody/collisionBitMask
+        // https://stackoverflow.com/questions/39063949/cant-understand-how-collision-bit-mask-works
         class BitmaskContactFilter : public dart::collision::BodyNodeCollisionFilter {
         public:
             using DartCollisionConstPtr = const dart::collision::CollisionObject*;
             using DartShapeConstPtr = const dart::dynamics::ShapeNode*;
+
+            struct Masks {
+                uint32_t collision_mask = 0xffffffff;
+                uint32_t category_mask = 0xffffffff;
+            };
 
             virtual ~BitmaskContactFilter() = default;
 
@@ -42,22 +48,30 @@ namespace robot_dart {
 
                 auto shape1_iter = _bitmask_map.find(shape_node1);
                 auto shape2_iter = _bitmask_map.find(shape_node2);
-                if (shape1_iter != _bitmask_map.end() && shape2_iter != _bitmask_map.end() && ((shape1_iter->second & shape2_iter->second) == 0))
-                    return true;
+                if (shape1_iter != _bitmask_map.end() && shape2_iter != _bitmask_map.end()) {
+                    auto col_mask1 = shape1_iter->second.collision_mask;
+                    auto cat_mask1 = shape1_iter->second.category_mask;
+
+                    auto col_mask2 = shape2_iter->second.collision_mask;
+                    auto cat_mask2 = shape2_iter->second.category_mask;
+
+                    if ((col_mask1 & cat_mask2) == 0 && (col_mask2 & cat_mask1) == 0)
+                        return true;
+                }
 
                 return false;
             }
 
-            void add_to_map(DartShapeConstPtr shape, const uint16_t mask)
+            void add_to_map(DartShapeConstPtr shape, uint32_t col_mask, uint32_t cat_mask)
             {
-                _bitmask_map[shape] = mask;
+                _bitmask_map[shape] = {col_mask, cat_mask};
             }
 
-            void add_to_map(dart::dynamics::SkeletonPtr skel, const uint16_t mask)
+            void add_to_map(dart::dynamics::SkeletonPtr skel, uint32_t col_mask, uint32_t cat_mask)
             {
                 for (std::size_t i = 0; i < skel->getNumShapeNodes(); ++i) {
                     auto shape = skel->getShapeNode(i);
-                    this->add_to_map(shape, mask);
+                    this->add_to_map(shape, col_mask, cat_mask);
                 }
             }
 
@@ -78,18 +92,18 @@ namespace robot_dart {
 
             void clear_all() { _bitmask_map.clear(); }
 
-            uint16_t mask(DartShapeConstPtr shape) const
+            Masks mask(DartShapeConstPtr shape) const
             {
                 auto shape_iter = _bitmask_map.find(shape);
                 if (shape_iter != _bitmask_map.end())
                     return shape_iter->second;
-                return 0xff;
+                return {0xffffffff, 0xffffffff};
             }
 
         private:
             // We need ShapeNodes and not BodyNodes, since in DART collision checking is performed in ShapeNode-level
             // in RobotDARTSimu, we only allow setting one mask per BodyNode; maybe we can improve the performance of this slightly
-            std::unordered_map<DartShapeConstPtr, uint16_t> _bitmask_map;
+            std::unordered_map<DartShapeConstPtr, Masks> _bitmask_map;
         };
     } // namespace collision_filter
 
@@ -542,24 +556,24 @@ namespace robot_dart {
 
     const std::string& RobotDARTSimu::collision_detector() const { return _world->getConstraintSolver()->getCollisionDetector()->getType(); }
 
-    void RobotDARTSimu::set_collision_mask(size_t robot_index, uint16_t mask)
+    void RobotDARTSimu::set_collision_masks(size_t robot_index, uint32_t category_mask, uint32_t collision_mask)
     {
         ROBOT_DART_ASSERT(robot_index < _robots.size(), "Robot index out of bounds", );
         auto coll_filter = std::static_pointer_cast<collision_filter::BitmaskContactFilter>(_world->getConstraintSolver()->getCollisionOption().collisionFilter);
-        coll_filter->add_to_map(_robots[robot_index]->skeleton(), mask);
+        coll_filter->add_to_map(_robots[robot_index]->skeleton(), collision_mask, category_mask);
     }
 
-    void RobotDARTSimu::set_collision_mask(size_t robot_index, const std::string& body_name, uint16_t mask)
+    void RobotDARTSimu::set_collision_masks(size_t robot_index, const std::string& body_name, uint32_t category_mask, uint32_t collision_mask)
     {
         ROBOT_DART_ASSERT(robot_index < _robots.size(), "Robot index out of bounds", );
         auto bd = _robots[robot_index]->skeleton()->getBodyNode(body_name);
         ROBOT_DART_ASSERT(bd != nullptr, "BodyNode does not exist in skeleton!", );
         auto coll_filter = std::static_pointer_cast<collision_filter::BitmaskContactFilter>(_world->getConstraintSolver()->getCollisionOption().collisionFilter);
         for (auto& shape : bd->getShapeNodes())
-            coll_filter->add_to_map(shape, mask);
+            coll_filter->add_to_map(shape, collision_mask, category_mask);
     }
 
-    void RobotDARTSimu::set_collision_mask(size_t robot_index, size_t body_index, uint16_t mask)
+    void RobotDARTSimu::set_collision_masks(size_t robot_index, size_t body_index, uint32_t category_mask, uint32_t collision_mask)
     {
         ROBOT_DART_ASSERT(robot_index < _robots.size(), "Robot index out of bounds", );
         auto skel = _robots[robot_index]->skeleton();
@@ -567,46 +581,108 @@ namespace robot_dart {
         auto bd = skel->getBodyNode(body_index);
         auto coll_filter = std::static_pointer_cast<collision_filter::BitmaskContactFilter>(_world->getConstraintSolver()->getCollisionOption().collisionFilter);
         for (auto& shape : bd->getShapeNodes())
-            coll_filter->add_to_map(shape, mask);
+            coll_filter->add_to_map(shape, collision_mask, category_mask);
     }
 
-    uint16_t RobotDARTSimu::collision_mask(size_t robot_index, const std::string& body_name)
+    uint32_t RobotDARTSimu::collision_mask(size_t robot_index, const std::string& body_name)
     {
-        ROBOT_DART_ASSERT(robot_index < _robots.size(), "Robot index out of bounds", 0xff);
+        ROBOT_DART_ASSERT(robot_index < _robots.size(), "Robot index out of bounds", 0xffffffff);
         auto bd = _robots[robot_index]->skeleton()->getBodyNode(body_name);
-        ROBOT_DART_ASSERT(bd != nullptr, "BodyNode does not exist in skeleton!", 0xff);
+        ROBOT_DART_ASSERT(bd != nullptr, "BodyNode does not exist in skeleton!", 0xffffffff);
         auto coll_filter = std::static_pointer_cast<collision_filter::BitmaskContactFilter>(_world->getConstraintSolver()->getCollisionOption().collisionFilter);
 
-        uint16_t mask = 0xff;
+        uint32_t mask = 0xffffffff;
         for (auto& shape : bd->getShapeNodes())
-            mask &= coll_filter->mask(shape);
+            mask &= coll_filter->mask(shape).collision_mask;
 
         return mask;
     }
 
-    uint16_t RobotDARTSimu::collision_mask(size_t robot_index, size_t body_index)
+    uint32_t RobotDARTSimu::collision_mask(size_t robot_index, size_t body_index)
     {
-        ROBOT_DART_ASSERT(robot_index < _robots.size(), "Robot index out of bounds", 0xff);
+        ROBOT_DART_ASSERT(robot_index < _robots.size(), "Robot index out of bounds", 0xffffffff);
         auto skel = _robots[robot_index]->skeleton();
-        ROBOT_DART_ASSERT(body_index < skel->getNumBodyNodes(), "BodyNode index out of bounds", 0xff);
+        ROBOT_DART_ASSERT(body_index < skel->getNumBodyNodes(), "BodyNode index out of bounds", 0xffffffff);
         auto bd = skel->getBodyNode(body_index);
         auto coll_filter = std::static_pointer_cast<collision_filter::BitmaskContactFilter>(_world->getConstraintSolver()->getCollisionOption().collisionFilter);
 
-        uint16_t mask = 0xff;
+        uint32_t mask = 0xffffffff;
         for (auto& shape : bd->getShapeNodes())
-            mask &= coll_filter->mask(shape);
+            mask &= coll_filter->mask(shape).collision_mask;
 
         return mask;
     }
 
-    void RobotDARTSimu::remove_collision_mask(size_t robot_index)
+    uint32_t RobotDARTSimu::collision_category(size_t robot_index, const std::string& body_name)
+    {
+        ROBOT_DART_ASSERT(robot_index < _robots.size(), "Robot index out of bounds", 0xffffffff);
+        auto bd = _robots[robot_index]->skeleton()->getBodyNode(body_name);
+        ROBOT_DART_ASSERT(bd != nullptr, "BodyNode does not exist in skeleton!", 0xffffffff);
+        auto coll_filter = std::static_pointer_cast<collision_filter::BitmaskContactFilter>(_world->getConstraintSolver()->getCollisionOption().collisionFilter);
+
+        uint32_t mask = 0xffffffff;
+        for (auto& shape : bd->getShapeNodes())
+            mask &= coll_filter->mask(shape).category_mask;
+
+        return mask;
+    }
+
+    uint32_t RobotDARTSimu::collision_category(size_t robot_index, size_t body_index)
+    {
+        ROBOT_DART_ASSERT(robot_index < _robots.size(), "Robot index out of bounds", 0xffffffff);
+        auto skel = _robots[robot_index]->skeleton();
+        ROBOT_DART_ASSERT(body_index < skel->getNumBodyNodes(), "BodyNode index out of bounds", 0xffffffff);
+        auto bd = skel->getBodyNode(body_index);
+        auto coll_filter = std::static_pointer_cast<collision_filter::BitmaskContactFilter>(_world->getConstraintSolver()->getCollisionOption().collisionFilter);
+
+        uint32_t mask = 0xffffffff;
+        for (auto& shape : bd->getShapeNodes())
+            mask &= coll_filter->mask(shape).category_mask;
+
+        return mask;
+    }
+
+    std::pair<uint32_t, uint32_t> RobotDARTSimu::collision_masks(size_t robot_index, const std::string& body_name)
+    {
+        std::pair<uint32_t, uint32_t> mask = {0xffffffff, 0xffffffff};
+        ROBOT_DART_ASSERT(robot_index < _robots.size(), "Robot index out of bounds", mask);
+        auto bd = _robots[robot_index]->skeleton()->getBodyNode(body_name);
+        ROBOT_DART_ASSERT(bd != nullptr, "BodyNode does not exist in skeleton!", mask);
+        auto coll_filter = std::static_pointer_cast<collision_filter::BitmaskContactFilter>(_world->getConstraintSolver()->getCollisionOption().collisionFilter);
+
+        for (auto& shape : bd->getShapeNodes()) {
+            mask.first &= coll_filter->mask(shape).collision_mask;
+            mask.second &= coll_filter->mask(shape).category_mask;
+        }
+
+        return mask;
+    }
+
+    std::pair<uint32_t, uint32_t> RobotDARTSimu::collision_masks(size_t robot_index, size_t body_index)
+    {
+        std::pair<uint32_t, uint32_t> mask = {0xffffffff, 0xffffffff};
+        ROBOT_DART_ASSERT(robot_index < _robots.size(), "Robot index out of bounds", mask);
+        auto skel = _robots[robot_index]->skeleton();
+        ROBOT_DART_ASSERT(body_index < skel->getNumBodyNodes(), "BodyNode index out of bounds", mask);
+        auto bd = skel->getBodyNode(body_index);
+        auto coll_filter = std::static_pointer_cast<collision_filter::BitmaskContactFilter>(_world->getConstraintSolver()->getCollisionOption().collisionFilter);
+
+        for (auto& shape : bd->getShapeNodes()) {
+            mask.first &= coll_filter->mask(shape).collision_mask;
+            mask.second &= coll_filter->mask(shape).category_mask;
+        }
+
+        return mask;
+    }
+
+    void RobotDARTSimu::remove_collision_masks(size_t robot_index)
     {
         ROBOT_DART_ASSERT(robot_index < _robots.size(), "Robot index out of bounds", );
         auto coll_filter = std::static_pointer_cast<collision_filter::BitmaskContactFilter>(_world->getConstraintSolver()->getCollisionOption().collisionFilter);
         coll_filter->remove_from_map(_robots[robot_index]->skeleton());
     }
 
-    void RobotDARTSimu::remove_collision_mask(size_t robot_index, const std::string& body_name)
+    void RobotDARTSimu::remove_collision_masks(size_t robot_index, const std::string& body_name)
     {
         ROBOT_DART_ASSERT(robot_index < _robots.size(), "Robot index out of bounds", );
         auto bd = _robots[robot_index]->skeleton()->getBodyNode(body_name);
@@ -616,7 +692,7 @@ namespace robot_dart {
             coll_filter->remove_from_map(shape);
     }
 
-    void RobotDARTSimu::remove_collision_mask(size_t robot_index, size_t body_index)
+    void RobotDARTSimu::remove_collision_masks(size_t robot_index, size_t body_index)
     {
         ROBOT_DART_ASSERT(robot_index < _robots.size(), "Robot index out of bounds", );
         auto skel = _robots[robot_index]->skeleton();

--- a/src/robot_dart/robot_dart_simu.hpp
+++ b/src/robot_dart/robot_dart_simu.hpp
@@ -120,16 +120,22 @@ namespace robot_dart {
         const std::string& collision_detector() const;
 
         // Bitmask collision filtering
-        void set_collision_mask(size_t robot_index, uint16_t mask);
-        void set_collision_mask(size_t robot_index, const std::string& body_name, uint16_t mask);
-        void set_collision_mask(size_t robot_index, size_t body_index, uint16_t mask);
+        void set_collision_masks(size_t robot_index, uint32_t category_mask, uint32_t collision_mask);
+        void set_collision_masks(size_t robot_index, const std::string& body_name, uint32_t category_mask, uint32_t collision_mask);
+        void set_collision_masks(size_t robot_index, size_t body_index, uint32_t category_mask, uint32_t collision_mask);
 
-        uint16_t collision_mask(size_t robot_index, const std::string& body_name);
-        uint16_t collision_mask(size_t robot_index, size_t body_index);
+        uint32_t collision_mask(size_t robot_index, const std::string& body_name);
+        uint32_t collision_mask(size_t robot_index, size_t body_index);
 
-        void remove_collision_mask(size_t robot_index);
-        void remove_collision_mask(size_t robot_index, const std::string& body_name);
-        void remove_collision_mask(size_t robot_index, size_t body_index);
+        uint32_t collision_category(size_t robot_index, const std::string& body_name);
+        uint32_t collision_category(size_t robot_index, size_t body_index);
+
+        std::pair<uint32_t, uint32_t> collision_masks(size_t robot_index, const std::string& body_name);
+        std::pair<uint32_t, uint32_t> collision_masks(size_t robot_index, size_t body_index);
+
+        void remove_collision_masks(size_t robot_index);
+        void remove_collision_masks(size_t robot_index, const std::string& body_name);
+        void remove_collision_masks(size_t robot_index, size_t body_index);
 
         void remove_all_collision_masks();
 


### PR DESCRIPTION
This PR fixes #136... The way to use this:

```
robot1:
    category_mask: 1 << 1
robot2:
    category_mask: 1 << 2
floor:
    category_mask: 1 << 3
```

This sets robot1 as category with number 2, robot2 as category with number 4, and floor as category with number 8. Now we set:

```
robot1:
    collision_mask: 4 | 8
robot2:
    collision_mask: 4
floor:
    collision_mask: 0
```

Collisions are ignored if `collision_mask & category_mask_of_other == 0`. In the above example, what will happen is that robot1 will collide with both robot2 and the floor, while robot2 will only collide with robot1.

Overall using the combinations of category and collision masks (per BodyNode), we can create a very complex collision ignorance systems.