### PR TITLE
Stricter warnings and avoid warnings of external libs

### DIFF
--- a/src/examples/iiwa_torque.cpp
+++ b/src/examples/iiwa_torque.cpp
@@ -58,7 +58,7 @@ int main()
 
     // Add a torque sensors to the robot
     int ct = 0;
-    std::shared_ptr<robot_dart::sensor::Torque> tq_sensors[robot->num_dofs()];
+    std::vector<std::shared_ptr<robot_dart::sensor::Torque>> tq_sensors(robot->num_dofs());
     for (const auto& joint : robot->dof_names())
         tq_sensors[ct++] = simu.add_sensor<robot_dart::sensor::Torque>(robot, joint, 1000);
 

--- a/src/examples/robot_pool.cpp
+++ b/src/examples/robot_pool.cpp
@@ -8,7 +8,7 @@
 
 static constexpr int NUM_THREADS = 12;
 
-void simulate_robot(const std::shared_ptr<robot_dart::Robot>& robot)
+inline void simulate_robot(const std::shared_ptr<robot_dart::Robot>& robot)
 {
     robot->set_position_enforced(true);
     auto positions = robot->positions();
@@ -51,7 +51,7 @@ void simulate_robot(const std::shared_ptr<robot_dart::Robot>& robot)
 }
 
 namespace pool {
-    std::shared_ptr<robot_dart::Robot> robot_creator()
+    inline std::shared_ptr<robot_dart::Robot> robot_creator()
     {
         std::vector<std::pair<std::string, std::string>> packages = {{"talos_description", "talos/talos_description"}};
         return std::make_shared<robot_dart::Robot>("talos/talos.urdf", packages);
@@ -60,7 +60,7 @@ namespace pool {
     robot_dart::RobotPool robot_pool(robot_creator, NUM_THREADS);
 } // namespace pool
 
-void eval_robot(int i)
+inline void eval_robot(int i)
 {
     auto robot = pool::robot_pool.get_robot();
     std::cout << "Robot " << i << " got [" << robot->skeleton() << "]" << std::endl;
@@ -77,7 +77,7 @@ void eval_robot(int i)
     std::cout << "Robot " << i << " freed!" << std::endl;
 }
 
-int main(int argc, char** argv)
+int main()
 {
     // for the example, we run NUM_THREADS threads of eval_robot()
     std::vector<std::thread> threads(NUM_THREADS * 2); // *2 to see some reuse

--- a/src/examples/transparent.cpp
+++ b/src/examples/transparent.cpp
@@ -7,7 +7,7 @@
 #include <robot_dart/gui/magnum/graphics.hpp>
 #endif
 
-std::shared_ptr<robot_dart::Robot> random_box(size_t num = 0)
+inline std::shared_ptr<robot_dart::Robot> random_box(size_t num = 0)
 {
     // random pose
     Eigen::Vector6d pose = Eigen::Vector6d::Random();
@@ -18,7 +18,7 @@ std::shared_ptr<robot_dart::Robot> random_box(size_t num = 0)
     return robot_dart::Robot::create_box(size, pose, "free", 1., dart::Color::Red(1.0), "box_" + std::to_string(num));
 }
 
-std::shared_ptr<robot_dart::Robot> random_sphere(size_t num = 0)
+inline std::shared_ptr<robot_dart::Robot> random_sphere(size_t num = 0)
 {
     // random pose
     Eigen::Vector6d pose = Eigen::Vector6d::Random();
@@ -33,7 +33,6 @@ std::shared_ptr<robot_dart::Robot> random_sphere(size_t num = 0)
 
 int main()
 {
-    std::srand(std::time(NULL));
     // choose time step of 0.001 seconds
     robot_dart::RobotDARTSimu simu(0.001);
 #ifdef GRAPHIC

--- a/src/examples/tutorial.cpp
+++ b/src/examples/tutorial.cpp
@@ -7,7 +7,7 @@
 #include <robot_dart/gui/magnum/graphics.hpp>
 #endif
 
-std::shared_ptr<robot_dart::Robot> random_box(size_t num = 0)
+inline std::shared_ptr<robot_dart::Robot> random_box(size_t num = 0)
 {
     // random pose
     Eigen::Vector6d pose = Eigen::Vector6d::Random();
@@ -18,7 +18,7 @@ std::shared_ptr<robot_dart::Robot> random_box(size_t num = 0)
     return robot_dart::Robot::create_box(size, pose, "free", 1., dart::Color::Red(1.0), "box_" + std::to_string(num));
 }
 
-std::shared_ptr<robot_dart::Robot> random_sphere(size_t num = 0)
+inline std::shared_ptr<robot_dart::Robot> random_sphere(size_t num = 0)
 {
     // random pose
     Eigen::Vector6d pose = Eigen::Vector6d::Random();

--- a/src/python/control.cpp
+++ b/src/python/control.cpp
@@ -115,8 +115,8 @@ namespace robot_dart {
                 .def("configure", &PDControl::configure)
                 .def("calculate", &PDControl::calculate)
 
-                .def("set_pd", (void (PDControl::*)(double, double)) & PDControl::set_pd)
-                .def("set_pd", (void (PDControl::*)(const Eigen::VectorXd&, const Eigen::VectorXd&)) & PDControl::set_pd)
+                .def("set_pd", static_cast<void (PDControl::*)(double, double)>(&PDControl::set_pd))
+                .def("set_pd", static_cast<void (PDControl::*)(const Eigen::VectorXd&, const Eigen::VectorXd&)>(&PDControl::set_pd))
 
                 .def("pd", &PDControl::pd)
 

--- a/src/python/control.cpp
+++ b/src/python/control.cpp
@@ -1,8 +1,5 @@
 #include "robot_dart.hpp"
-
-#include <pybind11/eigen.h>
-#include <pybind11/functional.h>
-#include <pybind11/stl.h>
+#include "utils_headers_pybind11.hpp"
 
 #include <robot_dart/robot.hpp>
 #include <robot_dart/robot_dart_simu.hpp>

--- a/src/python/eigen.cpp
+++ b/src/python/eigen.cpp
@@ -1,16 +1,14 @@
 #include "robot_dart.hpp"
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
 #include <Eigen/Dense>
 #include <Eigen/Geometry>
 
 #include <pybind11/eigen.h>
 
 #include <dart/math/Geometry.hpp>
-#pragma GCC diagnostic pop
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 namespace robot_dart {
     namespace python {

--- a/src/python/eigen.cpp
+++ b/src/python/eigen.cpp
@@ -1,11 +1,16 @@
 #include "robot_dart.hpp"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #include <Eigen/Dense>
 #include <Eigen/Geometry>
 
 #include <pybind11/eigen.h>
 
 #include <dart/math/Geometry.hpp>
+#pragma GCC diagnostic pop
 
 namespace robot_dart {
     namespace python {

--- a/src/python/eigen.cpp
+++ b/src/python/eigen.cpp
@@ -1,14 +1,6 @@
 #include "robot_dart.hpp"
-
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <Eigen/Dense>
-#include <Eigen/Geometry>
-
-#include <pybind11/eigen.h>
-
-#include <dart/math/Geometry.hpp>
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
+#include "utils_headers_eigen.hpp"
+#include "utils_headers_pybind11.hpp"
 
 namespace robot_dart {
     namespace python {

--- a/src/python/gui.cpp
+++ b/src/python/gui.cpp
@@ -1,15 +1,13 @@
 #include "robot_dart.hpp"
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
 #include <pybind11/eigen.h>
 #include <pybind11/functional.h>
 #include <pybind11/stl.h>
 
 #include <dart/dynamics/BodyNode.hpp>
-#pragma GCC diagnostic pop
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 #include <robot_dart/robot_dart_simu.hpp>
 

--- a/src/python/gui.cpp
+++ b/src/python/gui.cpp
@@ -1,13 +1,6 @@
 #include "robot_dart.hpp"
-
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <pybind11/eigen.h>
-#include <pybind11/functional.h>
-#include <pybind11/stl.h>
-
-#include <dart/dynamics/BodyNode.hpp>
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
+#include "utils_headers_dart.hpp"
+#include "utils_headers_pybind11.hpp"
 
 #include <robot_dart/robot_dart_simu.hpp>
 

--- a/src/python/gui.cpp
+++ b/src/python/gui.cpp
@@ -1,12 +1,17 @@
 #include "robot_dart.hpp"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #include <pybind11/eigen.h>
 #include <pybind11/functional.h>
 #include <pybind11/stl.h>
 
-#include <robot_dart/robot_dart_simu.hpp>
-
 #include <dart/dynamics/BodyNode.hpp>
+#pragma GCC diagnostic pop
+
+#include <robot_dart/robot_dart_simu.hpp>
 
 #ifdef GRAPHIC
 #include <robot_dart/gui/magnum/graphics.hpp>
@@ -175,11 +180,11 @@ namespace robot_dart {
                 .def("raw_depth_image", &Graphics::raw_depth_image)
                 .def("depth_array", &Graphics::depth_array)
 
-                .def("camera", (Camera & (Graphics::*)()) & Graphics::camera, py::return_value_policy::reference)
+                .def("camera", static_cast<Camera& (Graphics::*)()>(&Graphics::camera), py::return_value_policy::reference)
                 .def("camera_intrinsic_matrix", &Graphics::camera_intrinsic_matrix)
                 .def("camera_extrinsic_matrix", &Graphics::camera_extrinsic_matrix)
 
-                .def("magnum_app", (gui::magnum::BaseApplication * (Graphics::*)()) & Graphics::magnum_app, py::return_value_policy::reference)
+                .def("magnum_app", static_cast<gui::magnum::BaseApplication* (Graphics::*)()>(&Graphics::magnum_app), py::return_value_policy::reference)
 
                 .def_static("default_configuration", &Graphics::default_configuration);
 
@@ -223,11 +228,11 @@ namespace robot_dart {
                 .def("raw_depth_image", &WindowlessGraphics::raw_depth_image)
                 .def("depth_array", &WindowlessGraphics::depth_array)
 
-                .def("camera", (Camera & (WindowlessGraphics::*)()) & WindowlessGraphics::camera, py::return_value_policy::reference)
+                .def("camera", static_cast<Camera& (WindowlessGraphics::*)()>(&WindowlessGraphics::camera), py::return_value_policy::reference)
                 .def("camera_intrinsic_matrix", &WindowlessGraphics::camera_intrinsic_matrix)
                 .def("camera_extrinsic_matrix", &WindowlessGraphics::camera_extrinsic_matrix)
 
-                .def("magnum_app", (gui::magnum::BaseApplication * (WindowlessGraphics::*)()) & WindowlessGraphics::magnum_app, py::return_value_policy::reference)
+                .def("magnum_app", static_cast<gui::magnum::BaseApplication* (WindowlessGraphics::*)()>(&WindowlessGraphics::magnum_app), py::return_value_policy::reference)
 
                 .def_static("default_configuration", &WindowlessGraphics::default_configuration);
 
@@ -269,7 +274,7 @@ namespace robot_dart {
                     py::arg("joint"),
                     py::arg("tf") = Eigen::Isometry3d::Identity())
 
-                .def("camera", (Camera & (gui::magnum::sensor::Camera::*)()) & gui::magnum::sensor::Camera::camera, py::return_value_policy::reference)
+                .def("camera", static_cast<Camera& (gui::magnum::sensor::Camera::*)()>(&gui::magnum::sensor::Camera::camera), py::return_value_policy::reference)
                 .def("camera_intrinsic_matrix", &gui::magnum::sensor::Camera::camera_intrinsic_matrix)
                 .def("camera_extrinsic_matrix", &gui::magnum::sensor::Camera::camera_extrinsic_matrix)
 
@@ -294,8 +299,8 @@ namespace robot_dart {
                 .def("depth_array", &gui::magnum::sensor::Camera::depth_array);
 
             // Helper functions
-            sm.def("save_png_image", (void (*)(const std::string&, const gui::Image&)) & gui::save_png_image);
-            sm.def("save_png_image", (void (*)(const std::string&, const gui::GrayscaleImage&)) & gui::save_png_image);
+            sm.def("save_png_image", static_cast<void (*)(const std::string&, const gui::Image&)>(&gui::save_png_image));
+            sm.def("save_png_image", static_cast<void (*)(const std::string&, const gui::GrayscaleImage&)>(&gui::save_png_image));
             sm.def("convert_rgb_to_grayscale", gui::convert_rgb_to_grayscale);
             sm.def("point_cloud_from_depth_array", gui::point_cloud_from_depth_array,
                 py::arg("depth_image"),

--- a/src/python/robot.cpp
+++ b/src/python/robot.cpp
@@ -1,16 +1,14 @@
 #include "robot_dart.hpp"
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
 #include <pybind11/eigen.h>
 #include <pybind11/stl.h>
 
 #include <dart/dynamics/BodyNode.hpp>
 #include <dart/dynamics/DegreeOfFreedom.hpp>
 #include <dart/dynamics/Joint.hpp>
-#pragma GCC diagnostic pop
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 #include <robot_dart/robot.hpp>
 

--- a/src/python/robot.cpp
+++ b/src/python/robot.cpp
@@ -1,15 +1,20 @@
 #include "robot_dart.hpp"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #include <pybind11/eigen.h>
 #include <pybind11/stl.h>
-
-#include <robot_dart/robot.hpp>
-
-#include <robot_dart/control/robot_control.hpp>
 
 #include <dart/dynamics/BodyNode.hpp>
 #include <dart/dynamics/DegreeOfFreedom.hpp>
 #include <dart/dynamics/Joint.hpp>
+#pragma GCC diagnostic pop
+
+#include <robot_dart/robot.hpp>
+
+#include <robot_dart/control/robot_control.hpp>
 
 namespace robot_dart {
     namespace python {
@@ -40,22 +45,22 @@ namespace robot_dart {
                     py::arg("ghost_color") = Eigen::Vector4d{0.3, 0.3, 0.3, 0.7})
                 .def("skeleton", &Robot::skeleton)
 
-                .def("body_node", (dart::dynamics::BodyNode * (Robot::*)(const std::string&)) & Robot::body_node, py::return_value_policy::reference,
+                .def("body_node", static_cast<dart::dynamics::BodyNode* (Robot::*)(const std::string&)>(&Robot::body_node), py::return_value_policy::reference,
                     py::arg("body_name"))
 
-                .def("body_node", (dart::dynamics::BodyNode * (Robot::*)(size_t)) & Robot::body_node, py::return_value_policy::reference,
+                .def("body_node", static_cast<dart::dynamics::BodyNode* (Robot::*)(size_t)>(&Robot::body_node), py::return_value_policy::reference,
                     py::arg("body_index"))
 
-                .def("joint", (dart::dynamics::Joint * (Robot::*)(const std::string&)) & Robot::joint, py::return_value_policy::reference,
+                .def("joint", static_cast<dart::dynamics::Joint* (Robot::*)(const std::string&)>(&Robot::joint), py::return_value_policy::reference,
                     py::arg("joint_name"))
 
-                .def("joint", (dart::dynamics::Joint * (Robot::*)(size_t)) & Robot::joint, py::return_value_policy::reference,
+                .def("joint", static_cast<dart::dynamics::Joint* (Robot::*)(size_t)>(&Robot::joint), py::return_value_policy::reference,
                     py::arg("joint_index"))
 
-                .def("dof", (dart::dynamics::DegreeOfFreedom * (Robot::*)(const std::string&)) & Robot::dof, py::return_value_policy::reference,
+                .def("dof", static_cast<dart::dynamics::DegreeOfFreedom* (Robot::*)(const std::string&)>(&Robot::dof), py::return_value_policy::reference,
                     py::arg("dof_name"))
 
-                .def("dof", (dart::dynamics::DegreeOfFreedom * (Robot::*)(size_t)) & Robot::dof, py::return_value_policy::reference,
+                .def("dof", static_cast<dart::dynamics::DegreeOfFreedom* (Robot::*)(size_t)>(&Robot::dof), py::return_value_policy::reference,
                     py::arg("dof_index"))
 
                 .def("name", &Robot::name)
@@ -72,8 +77,8 @@ namespace robot_dart {
                 .def("add_controller", &Robot::add_controller, py::keep_alive<2, 1>(),
                     py::arg("controller"),
                     py::arg("weight") = 1.)
-                .def("remove_controller", (void (Robot::*)(const std::shared_ptr<control::RobotControl>&)) & Robot::remove_controller)
-                .def("remove_controller", (void (Robot::*)(size_t)) & Robot::remove_controller)
+                .def("remove_controller", static_cast<void (Robot::*)(const std::shared_ptr<control::RobotControl>&)>(&Robot::remove_controller))
+                .def("remove_controller", static_cast<void (Robot::*)(size_t)>(&Robot::remove_controller))
                 .def("clear_controllers", &Robot::clear_controllers)
 
                 .def("fix_to_world", &Robot::fix_to_world)
@@ -110,106 +115,106 @@ namespace robot_dart {
                 .def("actuator_types", &Robot::actuator_types,
                     py::arg("joint_names") = std::vector<std::string>())
 
-                .def("set_position_enforced", (void (Robot::*)(const std::vector<bool>&, const std::vector<std::string>&)) & Robot::set_position_enforced,
+                .def("set_position_enforced", static_cast<void (Robot::*)(const std::vector<bool>&, const std::vector<std::string>&)>(&Robot::set_position_enforced),
                     py::arg("enforced"),
                     py::arg("dof_names") = std::vector<std::string>())
-                .def("set_position_enforced", (void (Robot::*)(bool, const std::vector<std::string>&)) & Robot::set_position_enforced,
+                .def("set_position_enforced", static_cast<void (Robot::*)(bool, const std::vector<std::string>&)>(&Robot::set_position_enforced),
                     py::arg("enforced"),
                     py::arg("dof_names") = std::vector<std::string>())
 
                 .def("position_enforced", &Robot::position_enforced,
                     py::arg("dof_names") = std::vector<std::string>())
 
-                .def("set_damping_coeffs", (void (Robot::*)(const std::vector<double>&, const std::vector<std::string>&)) & Robot::set_damping_coeffs,
+                .def("set_damping_coeffs", static_cast<void (Robot::*)(const std::vector<double>&, const std::vector<std::string>&)>(&Robot::set_damping_coeffs),
                     py::arg("damps"),
                     py::arg("dof_names") = std::vector<std::string>())
-                .def("set_damping_coeffs", (void (Robot::*)(double, const std::vector<std::string>&)) & Robot::set_damping_coeffs,
+                .def("set_damping_coeffs", static_cast<void (Robot::*)(double, const std::vector<std::string>&)>(&Robot::set_damping_coeffs),
                     py::arg("damps"),
                     py::arg("dof_names") = std::vector<std::string>())
 
                 .def("damping_coeffs", &Robot::damping_coeffs,
                     py::arg("dof_names") = std::vector<std::string>())
 
-                .def("set_coulomb_coeffs", (void (Robot::*)(const std::vector<double>&, const std::vector<std::string>&)) & Robot::set_coulomb_coeffs,
+                .def("set_coulomb_coeffs", static_cast<void (Robot::*)(const std::vector<double>&, const std::vector<std::string>&)>(&Robot::set_coulomb_coeffs),
                     py::arg("cfrictions"),
                     py::arg("dof_names") = std::vector<std::string>())
-                .def("set_coulomb_coeffs", (void (Robot::*)(double, const std::vector<std::string>&)) & Robot::set_coulomb_coeffs,
+                .def("set_coulomb_coeffs", static_cast<void (Robot::*)(double, const std::vector<std::string>&)>(&Robot::set_coulomb_coeffs),
                     py::arg("cfrictions"),
                     py::arg("dof_names") = std::vector<std::string>())
 
                 .def("coulomb_coeffs", &Robot::coulomb_coeffs,
                     py::arg("dof_names") = std::vector<std::string>())
 
-                .def("set_spring_stiffnesses", (void (Robot::*)(const std::vector<double>&, const std::vector<std::string>&)) & Robot::set_spring_stiffnesses,
+                .def("set_spring_stiffnesses", static_cast<void (Robot::*)(const std::vector<double>&, const std::vector<std::string>&)>(&Robot::set_spring_stiffnesses),
                     py::arg("stiffnesses"),
                     py::arg("dof_names") = std::vector<std::string>())
-                .def("set_spring_stiffnesses", (void (Robot::*)(double, const std::vector<std::string>&)) & Robot::set_spring_stiffnesses,
+                .def("set_spring_stiffnesses", static_cast<void (Robot::*)(double, const std::vector<std::string>&)>(&Robot::set_spring_stiffnesses),
                     py::arg("stiffnesses"),
                     py::arg("dof_names") = std::vector<std::string>())
 
                 .def("spring_stiffnesses", &Robot::spring_stiffnesses,
                     py::arg("dof_names") = std::vector<std::string>())
 
-                .def("set_friction_dir", (void (Robot::*)(const std::string&, const Eigen::Vector3d&)) & Robot::set_friction_dir,
+                .def("set_friction_dir", static_cast<void (Robot::*)(const std::string&, const Eigen::Vector3d&)>(&Robot::set_friction_dir),
                     py::arg("body_name"),
                     py::arg("direction"))
-                .def("set_friction_dir", (void (Robot::*)(size_t, const Eigen::Vector3d&)) & Robot::set_friction_dir,
+                .def("set_friction_dir", static_cast<void (Robot::*)(size_t, const Eigen::Vector3d&)>(&Robot::set_friction_dir),
                     py::arg("body_index"),
                     py::arg("direction"))
 
-                .def("friction_dir", (Eigen::Vector3d(Robot::*)(const std::string&)) & Robot::friction_dir,
+                .def("friction_dir", static_cast<Eigen::Vector3d (Robot::*)(const std::string&)>(&Robot::friction_dir),
                     py::arg("body_name"))
-                .def("friction_dir", (Eigen::Vector3d(Robot::*)(size_t)) & Robot::friction_dir,
+                .def("friction_dir", static_cast<Eigen::Vector3d (Robot::*)(size_t)>(&Robot::friction_dir),
                     py::arg("body_index"))
 
-                .def("set_friction_coeff", (void (Robot::*)(const std::string&, double)) & Robot::set_friction_coeff,
+                .def("set_friction_coeff", static_cast<void (Robot::*)(const std::string&, double)>(&Robot::set_friction_coeff),
                     py::arg("body_name"),
                     py::arg("value"))
-                .def("set_friction_coeff", (void (Robot::*)(size_t, double)) & Robot::set_friction_coeff,
+                .def("set_friction_coeff", static_cast<void (Robot::*)(size_t, double)>(&Robot::set_friction_coeff),
                     py::arg("body_index"),
                     py::arg("value"))
                 .def("set_friction_coeffs", &Robot::set_friction_coeffs,
                     py::arg("value"))
 
-                .def("friction_coeff", (double (Robot::*)(const std::string&)) & Robot::friction_coeff,
+                .def("friction_coeff", static_cast<double (Robot::*)(const std::string&)>(&Robot::friction_coeff),
                     py::arg("body_name"))
-                .def("friction_coeff", (double (Robot::*)(size_t)) & Robot::friction_coeff,
+                .def("friction_coeff", static_cast<double (Robot::*)(size_t)>(&Robot::friction_coeff),
                     py::arg("body_index"))
 
-                .def("set_secondary_friction_coeff", (void (Robot::*)(const std::string&, double)) & Robot::set_secondary_friction_coeff,
+                .def("set_secondary_friction_coeff", static_cast<void (Robot::*)(const std::string&, double)>(&Robot::set_secondary_friction_coeff),
                     py::arg("body_name"),
                     py::arg("value"))
-                .def("set_secondary_friction_coeff", (void (Robot::*)(size_t, double)) & Robot::set_secondary_friction_coeff,
+                .def("set_secondary_friction_coeff", static_cast<void (Robot::*)(size_t, double)>(&Robot::set_secondary_friction_coeff),
                     py::arg("body_index"),
                     py::arg("value"))
                 .def("set_secondary_friction_coeffs", &Robot::set_secondary_friction_coeffs,
                     py::arg("value"))
 
-                .def("secondary_friction_coeff", (double (Robot::*)(const std::string&)) & Robot::secondary_friction_coeff,
+                .def("secondary_friction_coeff", static_cast<double (Robot::*)(const std::string&)>(&Robot::secondary_friction_coeff),
                     py::arg("body_name"))
-                .def("secondary_friction_coeff", (double (Robot::*)(size_t)) & Robot::secondary_friction_coeff,
+                .def("secondary_friction_coeff", static_cast<double (Robot::*)(size_t)>(&Robot::secondary_friction_coeff),
                     py::arg("body_index"))
 
-                .def("set_restitution_coeff", (void (Robot::*)(const std::string&, double)) & Robot::set_restitution_coeff,
+                .def("set_restitution_coeff", static_cast<void (Robot::*)(const std::string&, double)>(&Robot::set_restitution_coeff),
                     py::arg("body_name"),
                     py::arg("value"))
-                .def("set_restitution_coeff", (void (Robot::*)(size_t, double)) & Robot::set_restitution_coeff,
+                .def("set_restitution_coeff", static_cast<void (Robot::*)(size_t, double)>(&Robot::set_restitution_coeff),
                     py::arg("body_index"),
                     py::arg("value"))
                 .def("set_restitution_coeffs", &Robot::set_restitution_coeffs,
                     py::arg("value"))
 
-                .def("restitution_coeff", (double (Robot::*)(const std::string&)) & Robot::restitution_coeff,
+                .def("restitution_coeff", static_cast<double (Robot::*)(const std::string&)>(&Robot::restitution_coeff),
                     py::arg("body_name"))
-                .def("restitution_coeff", (double (Robot::*)(size_t)) & Robot::restitution_coeff,
+                .def("restitution_coeff", static_cast<double (Robot::*)(size_t)>(&Robot::restitution_coeff),
                     py::arg("body_index"))
 
                 .def("base_pose", &Robot::base_pose)
                 .def("base_pose_vec", &Robot::base_pose_vec)
 
-                .def("set_base_pose", (void (Robot::*)(const Eigen::Isometry3d&)) & Robot::set_base_pose,
+                .def("set_base_pose", static_cast<void (Robot::*)(const Eigen::Isometry3d&)>(&Robot::set_base_pose),
                     py::arg("tf"))
-                .def("set_base_pose", (void (Robot::*)(const Eigen::Vector6d&)) & Robot::set_base_pose,
+                .def("set_base_pose", static_cast<void (Robot::*)(const Eigen::Vector6d&)>(&Robot::set_base_pose),
                     py::arg("pose"))
 
                 .def("num_dofs", &Robot::num_dofs)
@@ -296,74 +301,74 @@ namespace robot_dart {
 
                 .def("force_torque", &Robot::force_torque)
 
-                .def("set_external_force", (void (Robot::*)(const std::string&, const Eigen::Vector3d&, const Eigen::Vector3d&, bool, bool)) & Robot::set_external_force,
+                .def("set_external_force", static_cast<void (Robot::*)(const std::string&, const Eigen::Vector3d&, const Eigen::Vector3d&, bool, bool)>(&Robot::set_external_force),
                     py::arg("body_name"),
                     py::arg("force"),
                     py::arg("offset") = Eigen::Vector3d::Zero(),
                     py::arg("force_local") = false,
                     py::arg("offset_local") = true)
-                .def("set_external_force", (void (Robot::*)(size_t, const Eigen::Vector3d&, const Eigen::Vector3d&, bool, bool)) & Robot::set_external_force,
+                .def("set_external_force", static_cast<void (Robot::*)(size_t, const Eigen::Vector3d&, const Eigen::Vector3d&, bool, bool)>(&Robot::set_external_force),
                     py::arg("body_index"),
                     py::arg("force"),
                     py::arg("offset") = Eigen::Vector3d::Zero(),
                     py::arg("force_local") = false,
                     py::arg("offset_local") = true)
-                .def("add_external_force", (void (Robot::*)(const std::string&, const Eigen::Vector3d&, const Eigen::Vector3d&, bool, bool)) & Robot::add_external_force,
+                .def("add_external_force", static_cast<void (Robot::*)(const std::string&, const Eigen::Vector3d&, const Eigen::Vector3d&, bool, bool)>(&Robot::add_external_force),
                     py::arg("body_name"),
                     py::arg("force"),
                     py::arg("offset") = Eigen::Vector3d::Zero(),
                     py::arg("force_local") = false,
                     py::arg("offset_local") = true)
-                .def("add_external_force", (void (Robot::*)(size_t, const Eigen::Vector3d&, const Eigen::Vector3d&, bool, bool)) & Robot::add_external_force,
+                .def("add_external_force", static_cast<void (Robot::*)(size_t, const Eigen::Vector3d&, const Eigen::Vector3d&, bool, bool)>(&Robot::add_external_force),
                     py::arg("body_index"),
                     py::arg("force"),
                     py::arg("offset") = Eigen::Vector3d::Zero(),
                     py::arg("force_local") = false,
                     py::arg("offset_local") = true)
 
-                .def("set_external_torque", (void (Robot::*)(const std::string&, const Eigen::Vector3d&, bool)) & Robot::set_external_torque,
+                .def("set_external_torque", static_cast<void (Robot::*)(const std::string&, const Eigen::Vector3d&, bool)>(&Robot::set_external_torque),
                     py::arg("body_name"),
                     py::arg("torque"),
                     py::arg("local") = false)
-                .def("set_external_torque", (void (Robot::*)(size_t, const Eigen::Vector3d&, bool)) & Robot::set_external_torque,
+                .def("set_external_torque", static_cast<void (Robot::*)(size_t, const Eigen::Vector3d&, bool)>(&Robot::set_external_torque),
                     py::arg("body_index"),
                     py::arg("torque"),
                     py::arg("local") = false)
-                .def("add_external_torque", (void (Robot::*)(const std::string&, const Eigen::Vector3d&, bool)) & Robot::add_external_torque,
+                .def("add_external_torque", static_cast<void (Robot::*)(const std::string&, const Eigen::Vector3d&, bool)>(&Robot::add_external_torque),
                     py::arg("body_name"),
                     py::arg("torque"),
                     py::arg("local") = false)
-                .def("add_external_torque", (void (Robot::*)(size_t, const Eigen::Vector3d&, bool)) & Robot::add_external_torque,
+                .def("add_external_torque", static_cast<void (Robot::*)(size_t, const Eigen::Vector3d&, bool)>(&Robot::add_external_torque),
                     py::arg("body_index"),
                     py::arg("torque"),
                     py::arg("local") = false)
 
-                .def("external_forces", (Eigen::Vector6d(Robot::*)(const std::string& body_name) const) & Robot::external_forces)
-                .def("external_forces", (Eigen::Vector6d(Robot::*)(size_t body_index) const) & Robot::external_forces)
+                .def("external_forces", static_cast<Eigen::Vector6d (Robot::*)(const std::string& body_name) const>(&Robot::external_forces))
+                .def("external_forces", static_cast<Eigen::Vector6d (Robot::*)(size_t body_index) const>(&Robot::external_forces))
 
-                .def("body_pose", (Eigen::Isometry3d(Robot::*)(const std::string& body_name) const) & Robot::body_pose)
-                .def("body_pose", (Eigen::Isometry3d(Robot::*)(size_t body_index) const) & Robot::body_pose)
+                .def("body_pose", static_cast<Eigen::Isometry3d (Robot::*)(const std::string& body_name) const>(&Robot::body_pose))
+                .def("body_pose", static_cast<Eigen::Isometry3d (Robot::*)(size_t body_index) const>(&Robot::body_pose))
 
-                .def("body_pose_vec", (Eigen::Vector6d(Robot::*)(const std::string& body_name) const) & Robot::body_pose_vec)
-                .def("body_pose_vec", (Eigen::Vector6d(Robot::*)(size_t body_index) const) & Robot::body_pose_vec)
+                .def("body_pose_vec", static_cast<Eigen::Vector6d (Robot::*)(const std::string& body_name) const>(&Robot::body_pose_vec))
+                .def("body_pose_vec", static_cast<Eigen::Vector6d (Robot::*)(size_t body_index) const>(&Robot::body_pose_vec))
 
-                .def("body_velocity", (Eigen::Vector6d(Robot::*)(const std::string& body_name) const) & Robot::body_velocity)
-                .def("body_velocity", (Eigen::Vector6d(Robot::*)(size_t body_index) const) & Robot::body_velocity)
+                .def("body_velocity", static_cast<Eigen::Vector6d (Robot::*)(const std::string& body_name) const>(&Robot::body_velocity))
+                .def("body_velocity", static_cast<Eigen::Vector6d (Robot::*)(size_t body_index) const>(&Robot::body_velocity))
 
-                .def("body_acceleration", (Eigen::Vector6d(Robot::*)(const std::string& body_name) const) & Robot::body_acceleration)
-                .def("body_acceleration", (Eigen::Vector6d(Robot::*)(size_t body_index) const) & Robot::body_acceleration)
+                .def("body_acceleration", static_cast<Eigen::Vector6d (Robot::*)(const std::string& body_name) const>(&Robot::body_acceleration))
+                .def("body_acceleration", static_cast<Eigen::Vector6d (Robot::*)(size_t body_index) const>(&Robot::body_acceleration))
 
                 .def("body_names", &Robot::body_names)
                 .def("body_name", &Robot::body_name)
                 .def("set_body_name", &Robot::set_body_name)
 
-                .def("body_mass", (double (Robot::*)(const std::string& body_name) const) & Robot::body_mass)
-                .def("body_mass", (double (Robot::*)(size_t body_index) const) & Robot::body_mass)
+                .def("body_mass", static_cast<double (Robot::*)(const std::string& body_name) const>(&Robot::body_mass))
+                .def("body_mass", static_cast<double (Robot::*)(size_t body_index) const>(&Robot::body_mass))
 
-                .def("set_body_mass", (void (Robot::*)(const std::string& body_name, double mass)) & Robot::set_body_mass)
-                .def("set_body_mass", (void (Robot::*)(size_t body_index, double mass)) & Robot::set_body_mass)
-                .def("add_body_mass", (void (Robot::*)(const std::string& body_name, double mass)) & Robot::add_body_mass)
-                .def("add_body_mass", (void (Robot::*)(size_t body_index, double mass)) & Robot::add_body_mass)
+                .def("set_body_mass", static_cast<void (Robot::*)(const std::string& body_name, double mass)>(&Robot::set_body_mass))
+                .def("set_body_mass", static_cast<void (Robot::*)(size_t body_index, double mass)>(&Robot::set_body_mass))
+                .def("add_body_mass", static_cast<void (Robot::*)(const std::string& body_name, double mass)>(&Robot::add_body_mass))
+                .def("add_body_mass", static_cast<void (Robot::*)(size_t body_index, double mass)>(&Robot::add_body_mass))
 
                 .def("jacobian", &Robot::jacobian,
                     py::arg("body_name"),
@@ -416,8 +421,8 @@ namespace robot_dart {
                 .def("set_joint_name", &Robot::set_joint_name)
                 .def("joint_index", &Robot::joint_index)
 
-                .def("set_color_mode", (void (Robot::*)(const std::string&)) & Robot::set_color_mode)
-                .def("set_color_mode", (void (Robot::*)(const std::string&, const std::string&)) & Robot::set_color_mode)
+                .def("set_color_mode", static_cast<void (Robot::*)(const std::string&)>(&Robot::set_color_mode))
+                .def("set_color_mode", static_cast<void (Robot::*)(const std::string&, const std::string&)>(&Robot::set_color_mode))
 
                 .def("set_self_collision", &Robot::set_self_collision,
                     py::arg("enable_self_collisions") = true,

--- a/src/python/robot.cpp
+++ b/src/python/robot.cpp
@@ -1,14 +1,6 @@
 #include "robot_dart.hpp"
-
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <pybind11/eigen.h>
-#include <pybind11/stl.h>
-
-#include <dart/dynamics/BodyNode.hpp>
-#include <dart/dynamics/DegreeOfFreedom.hpp>
-#include <dart/dynamics/Joint.hpp>
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
+#include "utils_headers_dart.hpp"
+#include "utils_headers_pybind11.hpp"
 
 #include <robot_dart/robot.hpp>
 

--- a/src/python/robot_dart.hpp
+++ b/src/python/robot_dart.hpp
@@ -1,5 +1,7 @@
 #include <pybind11/pybind11.h>
 
+#include <robot_dart/utils.hpp>
+
 namespace py = pybind11;
 
 namespace robot_dart {

--- a/src/python/sensor.cpp
+++ b/src/python/sensor.cpp
@@ -1,14 +1,6 @@
 #include "robot_dart.hpp"
-
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <pybind11/eigen.h>
-#include <pybind11/operators.h>
-#include <pybind11/stl.h>
-
-#include <dart/dynamics/BodyNode.hpp>
-#include <dart/dynamics/Joint.hpp>
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
+#include "utils_headers_dart.hpp"
+#include "utils_headers_pybind11.hpp"
 
 #include <robot_dart/robot_dart_simu.hpp>
 #include <robot_dart/sensor/force_torque.hpp>

--- a/src/python/sensor.cpp
+++ b/src/python/sensor.cpp
@@ -1,16 +1,14 @@
 #include "robot_dart.hpp"
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
 #include <pybind11/eigen.h>
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
 
 #include <dart/dynamics/BodyNode.hpp>
 #include <dart/dynamics/Joint.hpp>
-#pragma GCC diagnostic pop
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 #include <robot_dart/robot_dart_simu.hpp>
 #include <robot_dart/sensor/force_torque.hpp>

--- a/src/python/sensor.cpp
+++ b/src/python/sensor.cpp
@@ -1,16 +1,21 @@
 #include "robot_dart.hpp"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #include <pybind11/eigen.h>
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
+
+#include <dart/dynamics/BodyNode.hpp>
+#include <dart/dynamics/Joint.hpp>
+#pragma GCC diagnostic pop
 
 #include <robot_dart/robot_dart_simu.hpp>
 #include <robot_dart/sensor/force_torque.hpp>
 #include <robot_dart/sensor/imu.hpp>
 #include <robot_dart/sensor/sensor.hpp>
-
-#include <dart/dynamics/BodyNode.hpp>
-#include <dart/dynamics/Joint.hpp>
 
 namespace robot_dart {
     namespace python {
@@ -140,20 +145,20 @@ namespace robot_dart {
                     py::arg("t"))
                 .def("type", &Sensor::type)
 
-                .def("attach_to_body", (void (Sensor::*)(dart::dynamics::BodyNode*, const Eigen::Isometry3d& tf)) & Sensor::attach_to_body,
+                .def("attach_to_body", static_cast<void (Sensor::*)(dart::dynamics::BodyNode*, const Eigen::Isometry3d& tf)>(&Sensor::attach_to_body),
                     py::arg("body"),
                     py::arg("tf") = Eigen::Isometry3d::Identity())
 
-                .def("attach_to_body", (void (Sensor::*)(const std::shared_ptr<Robot>&, const std::string&, const Eigen::Isometry3d& tf)) & Sensor::attach_to_body,
+                .def("attach_to_body", static_cast<void (Sensor::*)(const std::shared_ptr<Robot>&, const std::string&, const Eigen::Isometry3d& tf)>(&Sensor::attach_to_body),
                     py::arg("robot"),
                     py::arg("body_name"),
                     py::arg("tf") = Eigen::Isometry3d::Identity())
 
-                .def("attach_to_joint", (void (Sensor::*)(dart::dynamics::Joint*, const Eigen::Isometry3d& tf)) & Sensor::attach_to_joint,
+                .def("attach_to_joint", static_cast<void (Sensor::*)(dart::dynamics::Joint*, const Eigen::Isometry3d& tf)>(&Sensor::attach_to_joint),
                     py::arg("joint"),
                     py::arg("tf") = Eigen::Isometry3d::Identity())
 
-                .def("attach_to_joint", (void (Sensor::*)(const std::shared_ptr<Robot>&, const std::string&, const Eigen::Isometry3d& tf)) & Sensor::attach_to_joint,
+                .def("attach_to_joint", static_cast<void (Sensor::*)(const std::shared_ptr<Robot>&, const std::string&, const Eigen::Isometry3d& tf)>(&Sensor::attach_to_joint),
                     py::arg("robot"),
                     py::arg("joint_name"),
                     py::arg("tf") = Eigen::Isometry3d::Identity());
@@ -189,7 +194,7 @@ namespace robot_dart {
                 .def("torque", &sensor::ForceTorque::torque)
                 .def("wrench", &sensor::ForceTorque::wrench)
 
-                .def("attach_to_body", (void (sensor::ForceTorque::*)(dart::dynamics::BodyNode*, const Eigen::Isometry3d& tf)) & sensor::ForceTorque::attach_to_body,
+                .def("attach_to_body", static_cast<void (sensor::ForceTorque::*)(dart::dynamics::BodyNode*, const Eigen::Isometry3d& tf)>(&sensor::ForceTorque::attach_to_body),
                     py::arg("body"),
                     py::arg("tf") = Eigen::Isometry3d::Identity());
 
@@ -234,7 +239,7 @@ namespace robot_dart {
                 .def("angular_velocity", &sensor::IMU::angular_velocity)
                 .def("linear_acceleration", &sensor::IMU::linear_acceleration)
 
-                .def("attach_to_joint", (void (sensor::IMU::*)(dart::dynamics::Joint*, const Eigen::Isometry3d& tf)) & sensor::ForceTorque::attach_to_joint,
+                .def("attach_to_joint", static_cast<void (sensor::IMU::*)(dart::dynamics::Joint*, const Eigen::Isometry3d& tf)>(&sensor::ForceTorque::attach_to_joint),
                     py::arg("joint"),
                     py::arg("tf") = Eigen::Isometry3d::Identity());
         }

--- a/src/python/simu.cpp
+++ b/src/python/simu.cpp
@@ -1,11 +1,5 @@
 #include "robot_dart.hpp"
-
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <pybind11/eigen.h>
-#include <pybind11/operators.h>
-#include <pybind11/stl.h>
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
+#include "utils_headers_pybind11.hpp"
 
 #include <robot_dart/robot_dart_simu.hpp>
 

--- a/src/python/simu.cpp
+++ b/src/python/simu.cpp
@@ -1,13 +1,11 @@
 #include "robot_dart.hpp"
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
 #include <pybind11/eigen.h>
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
-#pragma GCC diagnostic pop
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 #include <robot_dart/robot_dart_simu.hpp>
 

--- a/src/python/simu.cpp
+++ b/src/python/simu.cpp
@@ -1,8 +1,13 @@
 #include "robot_dart.hpp"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #include <pybind11/eigen.h>
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
+#pragma GCC diagnostic pop
 
 #include <robot_dart/robot_dart_simu.hpp>
 
@@ -45,7 +50,7 @@ namespace robot_dart {
                 .def("step", &RobotDARTSimu::step,
                     py::arg("reset_commands") = false)
 
-                .def("scheduler", (Scheduler & (RobotDARTSimu::*)(void)) & RobotDARTSimu::scheduler, py::return_value_policy::reference)
+                .def("scheduler", static_cast<Scheduler& (RobotDARTSimu::*)(void)>(&RobotDARTSimu::scheduler), py::return_value_policy::reference)
                 .def("schedule", &RobotDARTSimu::schedule)
 
                 .def("physics_freq", &RobotDARTSimu::physics_freq)
@@ -61,14 +66,14 @@ namespace robot_dart {
 
                 .def("world", &RobotDARTSimu::world)
 
-                .def("add_sensor", (void (RobotDARTSimu::*)(const std::shared_ptr<sensor::Sensor>&)) & RobotDARTSimu::add_sensor,
+                .def("add_sensor", static_cast<void (RobotDARTSimu::*)(const std::shared_ptr<sensor::Sensor>&)>(&RobotDARTSimu::add_sensor),
                     py::keep_alive<2, 1>(),
                     py::arg("sensor"))
                 .def("sensors", &RobotDARTSimu::sensors)
                 .def("sensor", &RobotDARTSimu::sensor)
 
-                .def("remove_sensor", (void (RobotDARTSimu::*)(const std::shared_ptr<sensor::Sensor>&)) & RobotDARTSimu::remove_sensor)
-                .def("remove_sensor", (void (RobotDARTSimu::*)(size_t)) & RobotDARTSimu::remove_sensor)
+                .def("remove_sensor", static_cast<void (RobotDARTSimu::*)(const std::shared_ptr<sensor::Sensor>&)>(&RobotDARTSimu::remove_sensor))
+                .def("remove_sensor", static_cast<void (RobotDARTSimu::*)(size_t)>(&RobotDARTSimu::remove_sensor))
                 .def("remove_sensors", &RobotDARTSimu::remove_sensors,
                     py::arg("type"))
                 .def("clear_sensors", &RobotDARTSimu::clear_sensors)
@@ -90,8 +95,8 @@ namespace robot_dart {
 
                 .def("add_robot", &RobotDARTSimu::add_robot, py::keep_alive<2, 1>())
                 .def("add_visual_robot", &RobotDARTSimu::add_visual_robot, py::keep_alive<2, 1>())
-                .def("remove_robot", (void (RobotDARTSimu::*)(const std::shared_ptr<Robot>&)) & RobotDARTSimu::remove_robot)
-                .def("remove_robot", (void (RobotDARTSimu::*)(size_t)) & RobotDARTSimu::remove_robot)
+                .def("remove_robot", static_cast<void (RobotDARTSimu::*)(const std::shared_ptr<Robot>&)>(&RobotDARTSimu::remove_robot))
+                .def("remove_robot", static_cast<void (RobotDARTSimu::*)(size_t)>(&RobotDARTSimu::remove_robot))
                 .def("clear_robots", &RobotDARTSimu::clear_robots)
 
                 .def("enable_text_panel", &RobotDARTSimu::enable_text_panel,
@@ -133,22 +138,22 @@ namespace robot_dart {
                 .def("set_collision_detector", &RobotDARTSimu::set_collision_detector)
                 .def("collision_detector", &RobotDARTSimu::collision_detector)
 
-                .def("set_collision_masks", (void (RobotDARTSimu::*)(size_t, uint32_t, uint32_t)) & RobotDARTSimu::set_collision_masks)
-                .def("set_collision_masks", (void (RobotDARTSimu::*)(size_t, const std::string&, uint32_t, uint32_t)) & RobotDARTSimu::set_collision_masks)
-                .def("set_collision_masks", (void (RobotDARTSimu::*)(size_t, size_t, uint32_t, uint32_t)) & RobotDARTSimu::set_collision_masks)
+                .def("set_collision_masks", static_cast<void (RobotDARTSimu::*)(size_t, uint32_t, uint32_t)>(&RobotDARTSimu::set_collision_masks))
+                .def("set_collision_masks", static_cast<void (RobotDARTSimu::*)(size_t, const std::string&, uint32_t, uint32_t)>(&RobotDARTSimu::set_collision_masks))
+                .def("set_collision_masks", static_cast<void (RobotDARTSimu::*)(size_t, size_t, uint32_t, uint32_t)>(&RobotDARTSimu::set_collision_masks))
 
-                .def("collision_mask", (uint32_t(RobotDARTSimu::*)(size_t, const std::string&)) & RobotDARTSimu::collision_mask)
-                .def("collision_mask", (uint32_t(RobotDARTSimu::*)(size_t, size_t)) & RobotDARTSimu::collision_mask)
+                .def("collision_mask", static_cast<uint32_t (RobotDARTSimu::*)(size_t, const std::string&)>(&RobotDARTSimu::collision_mask))
+                .def("collision_mask", static_cast<uint32_t (RobotDARTSimu::*)(size_t, size_t)>(&RobotDARTSimu::collision_mask))
 
-                .def("collision_category", (uint32_t(RobotDARTSimu::*)(size_t, const std::string&)) & RobotDARTSimu::collision_category)
-                .def("collision_category", (uint32_t(RobotDARTSimu::*)(size_t, size_t)) & RobotDARTSimu::collision_category)
+                .def("collision_category", static_cast<uint32_t (RobotDARTSimu::*)(size_t, const std::string&)>(&RobotDARTSimu::collision_category))
+                .def("collision_category", static_cast<uint32_t (RobotDARTSimu::*)(size_t, size_t)>(&RobotDARTSimu::collision_category))
 
-                .def("collision_masks", (std::pair<uint32_t, uint32_t>(RobotDARTSimu::*)(size_t, const std::string&)) & RobotDARTSimu::collision_masks)
-                .def("collision_masks", (std::pair<uint32_t, uint32_t>(RobotDARTSimu::*)(size_t, size_t)) & RobotDARTSimu::collision_masks)
+                .def("collision_masks", static_cast<std::pair<uint32_t, uint32_t> (RobotDARTSimu::*)(size_t, const std::string&)>(&RobotDARTSimu::collision_masks))
+                .def("collision_masks", static_cast<std::pair<uint32_t, uint32_t> (RobotDARTSimu::*)(size_t, size_t)>(&RobotDARTSimu::collision_masks))
 
-                .def("remove_collision_masks", (void (RobotDARTSimu::*)(size_t)) & RobotDARTSimu::remove_collision_masks)
-                .def("remove_collision_masks", (void (RobotDARTSimu::*)(size_t, const std::string&)) & RobotDARTSimu::remove_collision_masks)
-                .def("remove_collision_masks", (void (RobotDARTSimu::*)(size_t, size_t)) & RobotDARTSimu::remove_collision_masks)
+                .def("remove_collision_masks", static_cast<void (RobotDARTSimu::*)(size_t)>(&RobotDARTSimu::remove_collision_masks))
+                .def("remove_collision_masks", static_cast<void (RobotDARTSimu::*)(size_t, const std::string&)>(&RobotDARTSimu::remove_collision_masks))
+                .def("remove_collision_masks", static_cast<void (RobotDARTSimu::*)(size_t, size_t)>(&RobotDARTSimu::remove_collision_masks))
 
                 .def("remove_all_collision_masks", &RobotDARTSimu::remove_all_collision_masks);
         }

--- a/src/python/utils_headers_dart.hpp
+++ b/src/python/utils_headers_dart.hpp
@@ -1,0 +1,10 @@
+#ifndef ROBOT_DART_PYTHON_HEADERS_DART_HPP
+#define ROBOT_DART_PYTHON_HEADERS_DART_HPP
+
+#pragma GCC system_header
+
+#include <dart/dynamics/BodyNode.hpp>
+#include <dart/dynamics/DegreeOfFreedom.hpp>
+#include <dart/dynamics/Joint.hpp>
+
+#endif

--- a/src/python/utils_headers_eigen.hpp
+++ b/src/python/utils_headers_eigen.hpp
@@ -1,0 +1,11 @@
+#ifndef ROBOT_DART_PYTHON_HEADERS_EIGEN_HPP
+#define ROBOT_DART_PYTHON_HEADERS_EIGEN_HPP
+
+#pragma GCC system_header
+
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
+
+#include <dart/math/Geometry.hpp>
+
+#endif

--- a/src/python/utils_headers_pybind11.hpp
+++ b/src/python/utils_headers_pybind11.hpp
@@ -1,0 +1,11 @@
+#ifndef ROBOT_DART_PYTHON_HEADERS_PYBIND11_HPP
+#define ROBOT_DART_PYTHON_HEADERS_PYBIND11_HPP
+
+#pragma GCC system_header
+
+#include <pybind11/eigen.h>
+#include <pybind11/functional.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#endif

--- a/src/robot_dart/control/pd_control.cpp
+++ b/src/robot_dart/control/pd_control.cpp
@@ -1,14 +1,7 @@
 #include "pd_control.hpp"
 #include "robot_dart/robot.hpp"
 #include "robot_dart/utils.hpp"
-
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <dart/dynamics/BallJoint.hpp>
-#include <dart/dynamics/EulerJoint.hpp>
-#include <dart/dynamics/FreeJoint.hpp>
-#include <dart/dynamics/RevoluteJoint.hpp>
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
+#include "robot_dart/utils_headers_dart_dynamics.hpp"
 
 namespace robot_dart {
     namespace control {

--- a/src/robot_dart/control/pd_control.cpp
+++ b/src/robot_dart/control/pd_control.cpp
@@ -2,10 +2,14 @@
 #include "robot_dart/robot.hpp"
 #include "robot_dart/utils.hpp"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #include <dart/dynamics/BallJoint.hpp>
 #include <dart/dynamics/EulerJoint.hpp>
 #include <dart/dynamics/FreeJoint.hpp>
 #include <dart/dynamics/RevoluteJoint.hpp>
+#pragma GCC diagnostic pop
 
 namespace robot_dart {
     namespace control {

--- a/src/robot_dart/control/pd_control.cpp
+++ b/src/robot_dart/control/pd_control.cpp
@@ -2,14 +2,13 @@
 #include "robot_dart/robot.hpp"
 #include "robot_dart/utils.hpp"
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
 #include <dart/dynamics/BallJoint.hpp>
 #include <dart/dynamics/EulerJoint.hpp>
 #include <dart/dynamics/FreeJoint.hpp>
 #include <dart/dynamics/RevoluteJoint.hpp>
-#pragma GCC diagnostic pop
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 namespace robot_dart {
     namespace control {

--- a/src/robot_dart/control/pd_control.hpp
+++ b/src/robot_dart/control/pd_control.hpp
@@ -1,7 +1,6 @@
 #ifndef ROBOT_DART_CONTROL_PD_CONTROL
 #define ROBOT_DART_CONTROL_PD_CONTROL
 
-#include <Eigen/Core>
 #include <utility>
 
 #include <robot_dart/control/robot_control.hpp>

--- a/src/robot_dart/control/policy_control.hpp
+++ b/src/robot_dart/control/policy_control.hpp
@@ -3,7 +3,6 @@
 
 #include <robot_dart/control/robot_control.hpp>
 #include <robot_dart/robot.hpp>
-#include <robot_dart/utils.hpp>
 
 namespace robot_dart {
     namespace control {

--- a/src/robot_dart/control/robot_control.cpp
+++ b/src/robot_dart/control/robot_control.cpp
@@ -2,7 +2,10 @@
 #include "robot_dart/robot.hpp"
 #include "robot_dart/utils.hpp"
 
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
 #include <dart/dynamics/DegreeOfFreedom.hpp>
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 namespace robot_dart {
     namespace control {

--- a/src/robot_dart/control/robot_control.cpp
+++ b/src/robot_dart/control/robot_control.cpp
@@ -1,11 +1,7 @@
 #include "robot_control.hpp"
 #include "robot_dart/robot.hpp"
 #include "robot_dart/utils.hpp"
-
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <dart/dynamics/DegreeOfFreedom.hpp>
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
+#include "robot_dart/utils_headers_dart_dynamics.hpp"
 
 namespace robot_dart {
     namespace control {

--- a/src/robot_dart/control/robot_control.hpp
+++ b/src/robot_dart/control/robot_control.hpp
@@ -1,12 +1,10 @@
 #ifndef ROBOT_DART_CONTROL_ROBOT_CONTROL
 #define ROBOT_DART_CONTROL_ROBOT_CONTROL
 
-#include <Eigen/Core>
+#include <robot_dart/utils.hpp>
 
 #include <memory>
 #include <vector>
-
-#include <dart/config.hpp>
 
 namespace robot_dart {
     class Robot;

--- a/src/robot_dart/gui/helper.cpp
+++ b/src/robot_dart/gui/helper.cpp
@@ -1,12 +1,7 @@
 #include "helper.hpp"
 
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <Eigen/Dense>
-
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 namespace robot_dart {
     namespace gui {

--- a/src/robot_dart/gui/helper.cpp
+++ b/src/robot_dart/gui/helper.cpp
@@ -1,14 +1,12 @@
 #include "helper.hpp"
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
 #include <Eigen/Dense>
 
-#pragma GCC diagnostic ignored "-Wmissing-declarations"
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"
-#pragma GCC diagnostic pop
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 namespace robot_dart {
     namespace gui {

--- a/src/robot_dart/gui/helper.cpp
+++ b/src/robot_dart/gui/helper.cpp
@@ -1,9 +1,14 @@
 #include "helper.hpp"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #include <Eigen/Dense>
 
+#pragma GCC diagnostic ignored "-Wmissing-declarations"
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"
+#pragma GCC diagnostic pop
 
 namespace robot_dart {
     namespace gui {

--- a/src/robot_dart/gui/helper.hpp
+++ b/src/robot_dart/gui/helper.hpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 
-#include <Eigen/Core>
+#include <robot_dart/utils.hpp>
 
 namespace robot_dart {
     namespace gui {

--- a/src/robot_dart/gui/magnum/base_application.cpp
+++ b/src/robot_dart/gui/magnum/base_application.cpp
@@ -3,12 +3,7 @@
 #include <robot_dart/gui/magnum/gs/helper.hpp>
 #include <robot_dart/robot_dart_simu.hpp>
 #include <robot_dart/utils.hpp>
-
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <dart/dynamics/SoftBodyNode.hpp>
-#include <dart/dynamics/SoftMeshShape.hpp>
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
+#include <robot_dart/utils_headers_dart_dynamics.hpp>
 
 #include <Corrade/Containers/StridedArrayView.h>
 #include <Corrade/Utility/Resource.h>

--- a/src/robot_dart/gui/magnum/base_application.cpp
+++ b/src/robot_dart/gui/magnum/base_application.cpp
@@ -4,12 +4,11 @@
 #include <robot_dart/robot_dart_simu.hpp>
 #include <robot_dart/utils.hpp>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
 #include <dart/dynamics/SoftBodyNode.hpp>
 #include <dart/dynamics/SoftMeshShape.hpp>
-#pragma GCC diagnostic pop
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 #include <Corrade/Containers/StridedArrayView.h>
 #include <Corrade/Utility/Resource.h>

--- a/src/robot_dart/gui/magnum/base_application.cpp
+++ b/src/robot_dart/gui/magnum/base_application.cpp
@@ -4,8 +4,12 @@
 #include <robot_dart/robot_dart_simu.hpp>
 #include <robot_dart/utils.hpp>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #include <dart/dynamics/SoftBodyNode.hpp>
 #include <dart/dynamics/SoftMeshShape.hpp>
+#pragma GCC diagnostic pop
 
 #include <Corrade/Containers/StridedArrayView.h>
 #include <Corrade/Utility/Resource.h>
@@ -470,7 +474,7 @@ namespace robot_dart {
                 for (size_t i = 0; i < _lights.size(); i++) {
                     if (!_lights[i].casts_shadows())
                         continue;
-                    bool isPointLight = (_lights[i].position().w() > 0.f) && (_lights[i].spot_cut_off() >= M_PI / 2.0);
+                    bool isPointLight = (_lights[i].position().w() > 0.f) && (_lights[i].spot_cut_off() >= M_PIf / 2.f);
                     bool cullFront = false;
                     Magnum::Matrix4 cameraMatrix;
                     Magnum::Float far_plane = 20.f, near_plane = 0.001f;
@@ -487,7 +491,7 @@ namespace robot_dart {
                             cullFront = false; // if false, peter panning will be quite a bit, but has better acne
                         }
                         /* Spotlights */
-                        else if (_lights[i].spot_cut_off() < M_PI / 2.0) {
+                        else if (_lights[i].spot_cut_off() < M_PIf / 2.f) {
                             Magnum::Vector3 position = _lights[i].position().xyz();
                             cameraMatrix = Magnum::Matrix4::lookAt(position, position + _lights[i].spot_direction().normalized(), Magnum::Vector3::yAxis());
 
@@ -782,7 +786,7 @@ namespace robot_dart {
                 for (size_t i = 0; i < _lights.size(); i++) {
                     /* There's no shadow texture/framebuffer for this light */
                     if (_shadow_data.size() <= i) {
-                        bool isPointLight = (_lights[i].position().w() > 0.f) && (_lights[i].spot_cut_off() >= M_PI / 2.0);
+                        bool isPointLight = (_lights[i].position().w() > 0.f) && (_lights[i].spot_cut_off() >= M_PIf / 2.f);
 
                         _shadow_data.push_back({});
 

--- a/src/robot_dart/gui/magnum/base_application.hpp
+++ b/src/robot_dart/gui/magnum/base_application.hpp
@@ -15,12 +15,7 @@
 #include <robot_dart/gui/magnum/gs/shadow_map_color.hpp>
 #include <robot_dart/gui/magnum/types.hpp>
 
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <dart/simulation/World.hpp>
-
-#include <Magnum/DartIntegration/World.h>
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
+#include <robot_dart/utils_headers_external_gui.hpp>
 
 #include <Magnum/GL/CubeMapTextureArray.h>
 #include <Magnum/GL/Framebuffer.h>

--- a/src/robot_dart/gui/magnum/base_application.hpp
+++ b/src/robot_dart/gui/magnum/base_application.hpp
@@ -15,7 +15,13 @@
 #include <robot_dart/gui/magnum/gs/shadow_map_color.hpp>
 #include <robot_dart/gui/magnum/types.hpp>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #include <dart/simulation/World.hpp>
+
+#include <Magnum/DartIntegration/World.h>
+#pragma GCC diagnostic pop
 
 #include <Magnum/GL/CubeMapTextureArray.h>
 #include <Magnum/GL/Framebuffer.h>
@@ -34,8 +40,6 @@
 #include <Magnum/Text/AbstractFont.h>
 #include <Magnum/Text/DistanceFieldGlyphCache.h>
 #include <Magnum/Text/Renderer.h>
-
-#include <Magnum/DartIntegration/World.h>
 
 #define get_gl_context_with_sleep(name, ms_sleep)                             \
     /* Create/Get GLContext */                                                \

--- a/src/robot_dart/gui/magnum/base_application.hpp
+++ b/src/robot_dart/gui/magnum/base_application.hpp
@@ -15,13 +15,12 @@
 #include <robot_dart/gui/magnum/gs/shadow_map_color.hpp>
 #include <robot_dart/gui/magnum/types.hpp>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
 #include <dart/simulation/World.hpp>
 
 #include <Magnum/DartIntegration/World.h>
-#pragma GCC diagnostic pop
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 #include <Magnum/GL/CubeMapTextureArray.h>
 #include <Magnum/GL/Framebuffer.h>

--- a/src/robot_dart/gui/magnum/base_graphics.hpp
+++ b/src/robot_dart/gui/magnum/base_graphics.hpp
@@ -4,15 +4,11 @@
 #include <robot_dart/gui/base.hpp>
 #include <robot_dart/gui/magnum/glfw_application.hpp>
 #include <robot_dart/gui/magnum/gs/helper.hpp>
+#include <robot_dart/gui/magnum/utils_headers_eigen.hpp>
 #include <robot_dart/robot_dart_simu.hpp>
 
 // We need this for CORRADE_RESOURCE_INITIALIZE
 #include <Corrade/Utility/Resource.h>
-
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <Magnum/EigenIntegration/Integration.h>
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 inline static void robot_dart_initialize_magnum_resources()
 {

--- a/src/robot_dart/gui/magnum/base_graphics.hpp
+++ b/src/robot_dart/gui/magnum/base_graphics.hpp
@@ -9,7 +9,10 @@
 // We need this for CORRADE_RESOURCE_INITIALIZE
 #include <Corrade/Utility/Resource.h>
 
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
 #include <Magnum/EigenIntegration/Integration.h>
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 inline static void robot_dart_initialize_magnum_resources()
 {

--- a/src/robot_dart/gui/magnum/gs/camera.cpp
+++ b/src/robot_dart/gui/magnum/gs/camera.cpp
@@ -20,7 +20,10 @@
 #include <Magnum/ImageView.h>
 #include <Magnum/PixelFormat.h>
 
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
 #include <Magnum/EigenIntegration/GeometryIntegration.h>
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 namespace robot_dart {
     namespace gui {

--- a/src/robot_dart/gui/magnum/gs/camera.cpp
+++ b/src/robot_dart/gui/magnum/gs/camera.cpp
@@ -20,10 +20,7 @@
 #include <Magnum/ImageView.h>
 #include <Magnum/PixelFormat.h>
 
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <Magnum/EigenIntegration/GeometryIntegration.h>
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
+#include <robot_dart/gui/magnum/utils_headers_eigen.hpp>
 
 namespace robot_dart {
     namespace gui {

--- a/src/robot_dart/gui/magnum/gs/camera.cpp
+++ b/src/robot_dart/gui/magnum/gs/camera.cpp
@@ -381,10 +381,10 @@ namespace robot_dart {
                         Corrade::Containers::StridedArrayView2D<Magnum::Color3ub> dst{Corrade::Containers::arrayCast<Magnum::Color3ub>(Corrade::Containers::arrayView(data)), {std::size_t(image.size().y()), std::size_t(image.size().x())}};
                         Corrade::Utility::copy(src, dst);
 #ifdef ROBOT_DART_HAS_BOOST_PROCESS
-                        _video_pipe.write((char*)data.data(), data.size());
+                        _video_pipe.write(reinterpret_cast<char*>(data.data()), data.size());
                         _video_pipe.flush();
 #else
-                        write(_video_fd[1], (char*)data.data(), data.size());
+                        write(_video_fd[1], reinterpret_cast<char*>(data.data()), data.size());
 #endif
                     }
                 }

--- a/src/robot_dart/gui/magnum/gs/helper.cpp
+++ b/src/robot_dart/gui/magnum/gs/helper.cpp
@@ -64,10 +64,13 @@ namespace robot_dart {
 
                     img.data = std::vector<double>(data.begin(), data.end());
 
+                    double zNear = static_cast<double>(near_plane);
+                    double zFar = static_cast<double>(far_plane);
+
                     // zNear * zFar / (zFar + d * (zNear - zFar));
                     for (auto& depth : img.data)
-                        // depth = (2. * near_plane) / (far_plane + near_plane - depth * (far_plane - near_plane));
-                        depth = (near_plane * far_plane) / (far_plane - depth * (far_plane - near_plane));
+                        // depth = (2. * zNear) / (zFar + zNear - depth * (zFar - zNear));
+                        depth = (zNear * zFar) / (zFar - depth * (zFar - zNear));
 
                     return img;
                 }

--- a/src/robot_dart/gui/magnum/sensor/camera.cpp
+++ b/src/robot_dart/gui/magnum/sensor/camera.cpp
@@ -11,8 +11,11 @@
 #include <Magnum/ImageView.h>
 #include <Magnum/PixelFormat.h>
 
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
 #include <Magnum/EigenIntegration/GeometryIntegration.h>
 #include <Magnum/EigenIntegration/Integration.h>
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 namespace robot_dart {
     namespace gui {

--- a/src/robot_dart/gui/magnum/sensor/camera.cpp
+++ b/src/robot_dart/gui/magnum/sensor/camera.cpp
@@ -11,11 +11,7 @@
 #include <Magnum/ImageView.h>
 #include <Magnum/PixelFormat.h>
 
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <Magnum/EigenIntegration/GeometryIntegration.h>
-#include <Magnum/EigenIntegration/Integration.h>
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
+#include <robot_dart/gui/magnum/utils_headers_eigen.hpp>
 
 namespace robot_dart {
     namespace gui {

--- a/src/robot_dart/gui/magnum/sensor/camera.hpp
+++ b/src/robot_dart/gui/magnum/sensor/camera.hpp
@@ -26,7 +26,7 @@ namespace robot_dart {
 
                     void attach_to_body(dart::dynamics::BodyNode* body, const Eigen::Isometry3d& tf = Eigen::Isometry3d::Identity()) override;
 
-                    void attach_to_joint(dart::dynamics::Joint* joint, const Eigen::Isometry3d& tf = Eigen::Isometry3d::Identity()) override
+                    void attach_to_joint(dart::dynamics::Joint*, const Eigen::Isometry3d&) override
                     {
                         ROBOT_DART_WARNING(true, "You cannot attach a camera to a joint!");
                     }

--- a/src/robot_dart/gui/magnum/utils_headers_eigen.hpp
+++ b/src/robot_dart/gui/magnum/utils_headers_eigen.hpp
@@ -1,0 +1,9 @@
+#ifndef ROBOT_DART_GUI_MAGNUM_UTILS_HEADERS_EXTERNAL_GUI_HPP
+#define ROBOT_DART_GUI_MAGNUM_UTILS_HEADERS_EXTERNAL_GUI_HPP
+
+#pragma GCC system_header
+
+#include <Magnum/EigenIntegration/GeometryIntegration.h>
+#include <Magnum/EigenIntegration/Integration.h>
+
+#endif

--- a/src/robot_dart/gui/stb_image_write.h
+++ b/src/robot_dart/gui/stb_image_write.h
@@ -147,6 +147,8 @@ LICENSE
 
 */
 
+#pragma GCC system_header
+
 #ifndef INCLUDE_STB_IMAGE_WRITE_H
 #define INCLUDE_STB_IMAGE_WRITE_H
 

--- a/src/robot_dart/gui_data.hpp
+++ b/src/robot_dart/gui_data.hpp
@@ -6,14 +6,13 @@
 #include <unordered_map>
 #include <vector>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
 #include <Eigen/Geometry>
 
 #include <dart/dynamics/BodyNode.hpp>
 #include <dart/dynamics/ShapeNode.hpp>
-#pragma GCC diagnostic pop
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 namespace robot_dart {
     namespace simu {

--- a/src/robot_dart/gui_data.hpp
+++ b/src/robot_dart/gui_data.hpp
@@ -6,10 +6,14 @@
 #include <unordered_map>
 #include <vector>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #include <Eigen/Geometry>
 
 #include <dart/dynamics/BodyNode.hpp>
 #include <dart/dynamics/ShapeNode.hpp>
+#pragma GCC diagnostic pop
 
 namespace robot_dart {
     namespace simu {

--- a/src/robot_dart/gui_data.hpp
+++ b/src/robot_dart/gui_data.hpp
@@ -2,17 +2,10 @@
 #define ROBOT_DART_SIMU_GUI_DATA_HPP
 
 #include "robot_dart_simu.hpp"
+#include "utils_headers_dart_dynamics.hpp"
 
 #include <unordered_map>
 #include <vector>
-
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <Eigen/Geometry>
-
-#include <dart/dynamics/BodyNode.hpp>
-#include <dart/dynamics/ShapeNode.hpp>
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 namespace robot_dart {
     namespace simu {

--- a/src/robot_dart/robot.cpp
+++ b/src/robot_dart/robot.cpp
@@ -3,6 +3,11 @@
 #include <boost/filesystem.hpp>
 #include <unistd.h>
 
+#include <robot_dart/robot.hpp>
+#include <robot_dart/utils.hpp>
+
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
 #include <dart/config.hpp>
 #include <dart/dynamics/BoxShape.hpp>
 #include <dart/dynamics/DegreeOfFreedom.hpp>
@@ -18,9 +23,7 @@
 #include <dart/utils/SkelParser.hpp>
 #include <dart/utils/sdf/SdfParser.hpp>
 #include <dart/utils/urdf/urdf.hpp>
-
-#include <robot_dart/robot.hpp>
-#include <robot_dart/utils.hpp>
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 // namespace alias for compatibility
 namespace dart {

--- a/src/robot_dart/robot.cpp
+++ b/src/robot_dart/robot.cpp
@@ -86,7 +86,7 @@ namespace robot_dart {
                 tmp = skeleton->getGravityForces();
             else if (content == 15)
                 tmp = skeleton->getCoriolisAndGravityForces();
-             else if (content == 16)
+            else if (content == 16)
                 tmp = skeleton->getConstraintForces();
 
             for (size_t i = 0; i < dof_names.size(); i++) {

--- a/src/robot_dart/robot.cpp
+++ b/src/robot_dart/robot.cpp
@@ -5,31 +5,8 @@
 
 #include <robot_dart/robot.hpp>
 #include <robot_dart/utils.hpp>
-
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <dart/config.hpp>
-#include <dart/dynamics/BoxShape.hpp>
-#include <dart/dynamics/DegreeOfFreedom.hpp>
-#include <dart/dynamics/EllipsoidShape.hpp>
-#include <dart/dynamics/FreeJoint.hpp>
-#include <dart/dynamics/MeshShape.hpp>
-#include <dart/dynamics/WeldJoint.hpp>
-#if DART_VERSION_AT_LEAST(7, 0, 0)
-#include <dart/io/SkelParser.hpp>
-#include <dart/io/sdf/SdfParser.hpp>
-#include <dart/io/urdf/urdf.hpp>
-#else
-#include <dart/utils/SkelParser.hpp>
-#include <dart/utils/sdf/SdfParser.hpp>
-#include <dart/utils/urdf/urdf.hpp>
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
-
-// namespace alias for compatibility
-namespace dart {
-    namespace io = utils;
-}
-#endif
+#include <robot_dart/utils_headers_dart_dynamics.hpp>
+#include <robot_dart/utils_headers_dart_io.hpp>
 
 #include <robot_dart/control/robot_control.hpp>
 

--- a/src/robot_dart/robot.hpp
+++ b/src/robot_dart/robot.hpp
@@ -3,8 +3,12 @@
 
 #include <unordered_map>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #include <dart/dynamics/MeshShape.hpp>
 #include <dart/dynamics/Skeleton.hpp>
+#pragma GCC diagnostic pop
 
 namespace robot_dart {
     namespace control {

--- a/src/robot_dart/robot.hpp
+++ b/src/robot_dart/robot.hpp
@@ -3,12 +3,13 @@
 
 #include <unordered_map>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+#include <robot_dart/utils.hpp>
+
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
 #include <dart/dynamics/MeshShape.hpp>
 #include <dart/dynamics/Skeleton.hpp>
-#pragma GCC diagnostic pop
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 namespace robot_dart {
     namespace control {

--- a/src/robot_dart/robot.hpp
+++ b/src/robot_dart/robot.hpp
@@ -5,12 +5,6 @@
 
 #include <robot_dart/utils.hpp>
 
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <dart/dynamics/MeshShape.hpp>
-#include <dart/dynamics/Skeleton.hpp>
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
-
 namespace robot_dart {
     namespace control {
         class RobotControl;

--- a/src/robot_dart/robot_dart_simu.cpp
+++ b/src/robot_dart/robot_dart_simu.cpp
@@ -1,28 +1,10 @@
 #include "robot_dart_simu.hpp"
 #include "gui_data.hpp"
 #include "utils.hpp"
+#include "utils_headers_dart_collision.hpp"
+#include "utils_headers_dart_dynamics.hpp"
 
 #include <sstream>
-
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <dart/collision/CollisionFilter.hpp>
-#include <dart/collision/CollisionObject.hpp>
-#include <dart/collision/dart/DARTCollisionDetector.hpp>
-#include <dart/collision/fcl/FCLCollisionDetector.hpp>
-#include <dart/config.hpp>
-#include <dart/constraint/ConstraintSolver.hpp>
-#include <dart/dynamics/BoxShape.hpp>
-#include <dart/dynamics/WeldJoint.hpp>
-
-#if (HAVE_BULLET == 1)
-#include <dart/collision/bullet/BulletCollisionDetector.hpp>
-#endif
-
-#if (HAVE_ODE == 1)
-#include <dart/collision/ode/OdeCollisionDetector.hpp>
-#endif
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 namespace robot_dart {
     namespace collision_filter {

--- a/src/robot_dart/robot_dart_simu.cpp
+++ b/src/robot_dart/robot_dart_simu.cpp
@@ -4,6 +4,8 @@
 
 #include <sstream>
 
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
 #include <dart/collision/CollisionFilter.hpp>
 #include <dart/collision/CollisionObject.hpp>
 #include <dart/collision/dart/DARTCollisionDetector.hpp>
@@ -20,6 +22,7 @@
 #if (HAVE_ODE == 1)
 #include <dart/collision/ode/OdeCollisionDetector.hpp>
 #endif
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 namespace robot_dart {
     namespace collision_filter {

--- a/src/robot_dart/robot_dart_simu.hpp
+++ b/src/robot_dart/robot_dart_simu.hpp
@@ -6,11 +6,6 @@
 #include <robot_dart/scheduler.hpp>
 #include <robot_dart/sensor/sensor.hpp>
 
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <dart/simulation/World.hpp>
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
-
 namespace robot_dart {
     namespace simu {
         struct GUIData;

--- a/src/robot_dart/robot_dart_simu.hpp
+++ b/src/robot_dart/robot_dart_simu.hpp
@@ -1,16 +1,15 @@
 #ifndef ROBOT_DART_SIMU_HPP
 #define ROBOT_DART_SIMU_HPP
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
-#include <dart/simulation/World.hpp>
-#pragma GCC diagnostic pop
-
 #include <robot_dart/gui/base.hpp>
 #include <robot_dart/robot.hpp>
 #include <robot_dart/scheduler.hpp>
 #include <robot_dart/sensor/sensor.hpp>
+
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
+#include <dart/simulation/World.hpp>
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 namespace robot_dart {
     namespace simu {

--- a/src/robot_dart/robot_dart_simu.hpp
+++ b/src/robot_dart/robot_dart_simu.hpp
@@ -1,7 +1,11 @@
 #ifndef ROBOT_DART_SIMU_HPP
 #define ROBOT_DART_SIMU_HPP
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #include <dart/simulation/World.hpp>
+#pragma GCC diagnostic pop
 
 #include <robot_dart/gui/base.hpp>
 #include <robot_dart/robot.hpp>

--- a/src/robot_dart/robot_pool.cpp
+++ b/src/robot_dart/robot_pool.cpp
@@ -1,7 +1,7 @@
 #include <robot_dart/robot_pool.hpp>
 
 namespace robot_dart {
-    RobotPool::RobotPool(const std::function<std::shared_ptr<Robot>()>& robot_creator, size_t pool_size, bool verbose) : _robot_creator(robot_creator), _pool_size(pool_size), _verbose(true)
+    RobotPool::RobotPool(const std::function<std::shared_ptr<Robot>()>& robot_creator, size_t pool_size, bool verbose) : _robot_creator(robot_creator), _pool_size(pool_size), _verbose(verbose)
     {
         if (_verbose) {
             std::cout << "Creating a pool of " << pool_size << " robots: ";

--- a/src/robot_dart/robot_pool.hpp
+++ b/src/robot_dart/robot_pool.hpp
@@ -1,5 +1,5 @@
-#ifndef _TALOS_CLONE_POOL
-#define _TALOS_CLONE_POOL
+#ifndef ROBOT_DART_ROBOT_POOL
+#define ROBOT_DART_ROBOT_POOL
 
 #include <functional>
 #include <memory>
@@ -23,6 +23,7 @@ namespace robot_dart {
         virtual void free_robot(const std::shared_ptr<Robot>& robot);
 
         const std::string& model_filename() const { return _model_filename; }
+
     protected:
         robot_creator_t _robot_creator;
         size_t _pool_size;

--- a/src/robot_dart/scheduler.hpp
+++ b/src/robot_dart/scheduler.hpp
@@ -4,7 +4,6 @@
 #include <robot_dart/utils.hpp>
 
 #include <chrono>
-#include <cmath>
 #include <thread>
 
 namespace robot_dart {

--- a/src/robot_dart/sensor/force_torque.cpp
+++ b/src/robot_dart/sensor/force_torque.cpp
@@ -18,7 +18,7 @@ namespace robot_dart {
             _active = true;
         }
 
-        void ForceTorque::calculate(double t)
+        void ForceTorque::calculate(double)
         {
             if (!_attached_to_joint)
                 return; // cannot compute anything if not attached to a joint

--- a/src/robot_dart/sensor/force_torque.cpp
+++ b/src/robot_dart/sensor/force_torque.cpp
@@ -1,10 +1,6 @@
 #include "force_torque.hpp"
 
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <dart/dynamics/BodyNode.hpp>
-#include <dart/dynamics/Joint.hpp>
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
+#include <robot_dart/utils_headers_dart_dynamics.hpp>
 
 namespace robot_dart {
     namespace sensor {

--- a/src/robot_dart/sensor/force_torque.cpp
+++ b/src/robot_dart/sensor/force_torque.cpp
@@ -1,7 +1,10 @@
 #include "force_torque.hpp"
 
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
 #include <dart/dynamics/BodyNode.hpp>
 #include <dart/dynamics/Joint.hpp>
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 namespace robot_dart {
     namespace sensor {

--- a/src/robot_dart/sensor/force_torque.hpp
+++ b/src/robot_dart/sensor/force_torque.hpp
@@ -12,7 +12,7 @@ namespace robot_dart {
 
             void init() override;
 
-            void calculate(double t) override;
+            void calculate(double) override;
 
             std::string type() const override;
 
@@ -20,7 +20,7 @@ namespace robot_dart {
             Eigen::Vector3d torque() const;
             const Eigen::Vector6d& wrench() const;
 
-            void attach_to_body(dart::dynamics::BodyNode* body, const Eigen::Isometry3d& tf = Eigen::Isometry3d::Identity()) override
+            void attach_to_body(dart::dynamics::BodyNode*, const Eigen::Isometry3d&) override
             {
                 ROBOT_DART_WARNING(true, "You cannot attach a force/torque sensor to a body!");
             }

--- a/src/robot_dart/sensor/imu.cpp
+++ b/src/robot_dart/sensor/imu.cpp
@@ -18,7 +18,7 @@ namespace robot_dart {
                 _active = true;
         }
 
-        void IMU::calculate(double t)
+        void IMU::calculate(double)
         {
             if (!_attached_to_body)
                 return; // cannot compute anything if not attached to a link

--- a/src/robot_dart/sensor/imu.cpp
+++ b/src/robot_dart/sensor/imu.cpp
@@ -1,11 +1,7 @@
 #include "imu.hpp"
 
 #include <robot_dart/robot_dart_simu.hpp>
-
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <dart/dynamics/BodyNode.hpp>
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
+#include <robot_dart/utils_headers_dart_dynamics.hpp>
 
 namespace robot_dart {
     namespace sensor {

--- a/src/robot_dart/sensor/imu.cpp
+++ b/src/robot_dart/sensor/imu.cpp
@@ -2,7 +2,10 @@
 
 #include <robot_dart/robot_dart_simu.hpp>
 
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
 #include <dart/dynamics/BodyNode.hpp>
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 namespace robot_dart {
     namespace sensor {

--- a/src/robot_dart/sensor/imu.hpp
+++ b/src/robot_dart/sensor/imu.hpp
@@ -29,7 +29,7 @@ namespace robot_dart {
 
             void init() override;
 
-            void calculate(double t) override;
+            void calculate(double) override;
 
             std::string type() const override;
 
@@ -38,7 +38,7 @@ namespace robot_dart {
             const Eigen::Vector3d& angular_velocity() const;
             const Eigen::Vector3d& linear_acceleration() const;
 
-            void attach_to_joint(dart::dynamics::Joint* joint, const Eigen::Isometry3d& tf = Eigen::Isometry3d::Identity()) override
+            void attach_to_joint(dart::dynamics::Joint*, const Eigen::Isometry3d&) override
             {
                 ROBOT_DART_WARNING(true, "You cannot attach an IMU sensor to a joint!");
             }

--- a/src/robot_dart/sensor/sensor.cpp
+++ b/src/robot_dart/sensor/sensor.cpp
@@ -1,12 +1,7 @@
 #include "sensor.hpp"
 #include "robot_dart/robot_dart_simu.hpp"
 #include "robot_dart/utils.hpp"
-
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <dart/dynamics/BodyNode.hpp>
-#include <dart/dynamics/Joint.hpp>
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
+#include "robot_dart/utils_headers_dart_dynamics.hpp"
 
 namespace robot_dart {
     namespace sensor {

--- a/src/robot_dart/sensor/sensor.cpp
+++ b/src/robot_dart/sensor/sensor.cpp
@@ -2,8 +2,11 @@
 #include "robot_dart/robot_dart_simu.hpp"
 #include "robot_dart/utils.hpp"
 
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
 #include <dart/dynamics/BodyNode.hpp>
 #include <dart/dynamics/Joint.hpp>
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 namespace robot_dart {
     namespace sensor {

--- a/src/robot_dart/sensor/sensor.cpp
+++ b/src/robot_dart/sensor/sensor.cpp
@@ -46,7 +46,8 @@ namespace robot_dart {
         void Sensor::set_pose(const Eigen::Isometry3d& tf) { _world_pose = tf; }
         const Eigen::Isometry3d& Sensor::pose() const { return _world_pose; }
 
-        void Sensor::detach() {
+        void Sensor::detach()
+        {
             _attached_to_body = false;
             _attached_to_joint = false;
             _body_attached = nullptr;
@@ -124,7 +125,7 @@ namespace robot_dart {
             }
         }
         const std::string& Sensor::attached_to() const
-         { 
+        {
             ROBOT_DART_EXCEPTION_ASSERT(_attached_to_body || _attached_to_joint, "Joint is not attached to anything");
             if (_attached_to_body)
                 return _body_attached->getName();

--- a/src/robot_dart/sensor/sensor.hpp
+++ b/src/robot_dart/sensor/sensor.hpp
@@ -4,9 +4,6 @@
 #include <robot_dart/robot.hpp>
 #include <robot_dart/utils.hpp>
 
-#include <Eigen/Core>
-#include <Eigen/Geometry>
-
 #include <memory>
 #include <vector>
 

--- a/src/robot_dart/sensor/sensor.hpp
+++ b/src/robot_dart/sensor/sensor.hpp
@@ -39,7 +39,7 @@ namespace robot_dart {
 
             virtual void init() = 0;
             // TO-DO: Maybe make this const?
-            virtual void calculate(double t) = 0;
+            virtual void calculate(double) = 0;
 
             virtual std::string type() const = 0;
 
@@ -51,6 +51,7 @@ namespace robot_dart {
 
             void detach();
             const std::string& attached_to() const;
+
         protected:
             RobotDARTSimu* _simu = nullptr;
             bool _active;

--- a/src/robot_dart/sensor/torque.cpp
+++ b/src/robot_dart/sensor/torque.cpp
@@ -2,9 +2,8 @@
 
 #include <robot_dart/robot_dart_simu.hpp>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
 #include <dart/dynamics/BodyNode.hpp>
 #include <dart/dynamics/Joint.hpp>
 
@@ -19,7 +18,7 @@
 #include <dart/dynamics/TranslationalJoint2D.hpp>
 #include <dart/dynamics/UniversalJoint.hpp>
 #include <dart/dynamics/WeldJoint.hpp>
-#pragma GCC diagnostic pop
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 namespace robot_dart {
     namespace sensor {

--- a/src/robot_dart/sensor/torque.cpp
+++ b/src/robot_dart/sensor/torque.cpp
@@ -2,6 +2,9 @@
 
 #include <robot_dart/robot_dart_simu.hpp>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #include <dart/dynamics/BodyNode.hpp>
 #include <dart/dynamics/Joint.hpp>
 
@@ -16,6 +19,7 @@
 #include <dart/dynamics/TranslationalJoint2D.hpp>
 #include <dart/dynamics/UniversalJoint.hpp>
 #include <dart/dynamics/WeldJoint.hpp>
+#pragma GCC diagnostic pop
 
 namespace robot_dart {
     namespace sensor {
@@ -32,7 +36,7 @@ namespace robot_dart {
             _active = true;
         }
 
-        void Torque::calculate(double t)
+        void Torque::calculate(double)
         {
             if (!_attached_to_joint)
                 return; // cannot compute anything if not attached to a joint

--- a/src/robot_dart/sensor/torque.cpp
+++ b/src/robot_dart/sensor/torque.cpp
@@ -1,24 +1,7 @@
 #include "torque.hpp"
 
 #include <robot_dart/robot_dart_simu.hpp>
-
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <dart/dynamics/BodyNode.hpp>
-#include <dart/dynamics/Joint.hpp>
-
-#include <dart/dynamics/BallJoint.hpp>
-#include <dart/dynamics/EulerJoint.hpp>
-#include <dart/dynamics/FreeJoint.hpp>
-#include <dart/dynamics/PlanarJoint.hpp>
-#include <dart/dynamics/PrismaticJoint.hpp>
-#include <dart/dynamics/RevoluteJoint.hpp>
-#include <dart/dynamics/ScrewJoint.hpp>
-#include <dart/dynamics/TranslationalJoint.hpp>
-#include <dart/dynamics/TranslationalJoint2D.hpp>
-#include <dart/dynamics/UniversalJoint.hpp>
-#include <dart/dynamics/WeldJoint.hpp>
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
+#include <robot_dart/utils_headers_dart_dynamics.hpp>
 
 namespace robot_dart {
     namespace sensor {

--- a/src/robot_dart/sensor/torque.hpp
+++ b/src/robot_dart/sensor/torque.hpp
@@ -12,13 +12,13 @@ namespace robot_dart {
 
             void init() override;
 
-            void calculate(double t) override;
+            void calculate(double) override;
 
             std::string type() const override;
 
             const Eigen::VectorXd& torques() const;
 
-            void attach_to_body(dart::dynamics::BodyNode* body, const Eigen::Isometry3d& tf = Eigen::Isometry3d::Identity()) override
+            void attach_to_body(dart::dynamics::BodyNode*, const Eigen::Isometry3d&) override
             {
                 ROBOT_DART_WARNING(true, "You cannot attach a torque sensor to a body!");
             }

--- a/src/robot_dart/utils.hpp
+++ b/src/robot_dart/utils.hpp
@@ -1,39 +1,10 @@
 #ifndef ROBOT_DART_UTILS_HPP
 #define ROBOT_DART_UTILS_HPP
 
-#include <cstdlib>
 #include <exception>
 #include <iostream>
 
-#define ROBOT_DART_PRAGMA(x) _Pragma(#x)
-
-#define ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH ROBOT_DART_PRAGMA(GCC diagnostic push)
-#define ROBOT_DART_COMPILER_DIAGNOSTIC_POP ROBOT_DART_PRAGMA(GCC diagnostic pop)
-#if defined(__clang__)
-#define ROBOT_DART_COMPILER_IGNORE_WARNINGS                                     \
-    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wold-style-cast")                \
-    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wzero-as-null-pointer-constant") \
-    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wdeprecated-copy")               \
-    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wpedantic")                      \
-    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wmissing-declarations")          \
-    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wunused-parameter")
-#else // #elif defined(__GNUC__) || defined(__GNUG__)
-#define ROBOT_DART_COMPILER_IGNORE_WARNINGS                                     \
-    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wold-style-cast")                \
-    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wzero-as-null-pointer-constant") \
-    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wmaybe-uninitialized")           \
-    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wpedantic")                      \
-    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wmissing-declarations")          \
-    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wunused-parameter")
-#endif
-
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <Eigen/Core>
-#include <Eigen/Geometry>
-
-#include <dart/config.hpp>
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
+#include <robot_dart/utils_headers_external.hpp>
 
 #ifndef ROBOT_DART_SHOW_WARNINGS
 #define ROBOT_DART_SHOW_WARNINGS true

--- a/src/robot_dart/utils.hpp
+++ b/src/robot_dart/utils.hpp
@@ -5,11 +5,20 @@
 #include <exception>
 #include <iostream>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <dart/config.hpp>
+#pragma GCC diagnostic pop
 
 #ifndef ROBOT_DART_SHOW_WARNINGS
 #define ROBOT_DART_SHOW_WARNINGS true
 #endif
+
+#define M_PIf static_cast<float>(M_PI)
 
 namespace robot_dart {
 
@@ -39,6 +48,8 @@ namespace robot_dart {
         }
     };
 } // namespace robot_dart
+
+#define ROBOT_DART_UNUSED_VARIABLE(var) (void)(var)
 
 #define ROBOT_DART_WARNING(condition, message)                                   \
     if (ROBOT_DART_SHOW_WARNINGS && (condition)) {                               \

--- a/src/robot_dart/utils.hpp
+++ b/src/robot_dart/utils.hpp
@@ -9,7 +9,14 @@
 
 #define ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH ROBOT_DART_PRAGMA(GCC diagnostic push)
 #define ROBOT_DART_COMPILER_DIAGNOSTIC_POP ROBOT_DART_PRAGMA(GCC diagnostic pop)
-#ifdef __GNUC__
+#if defined(__clang__)
+#define ROBOT_DART_COMPILER_IGNORE_WARNINGS                                     \
+    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wold-style-cast")                \
+    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wzero-as-null-pointer-constant") \
+    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wdeprecated-copy")               \
+    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wpedantic")                      \
+    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wmissing-declarations")
+#else // #elif defined(__GNUC__) || defined(__GNUG__)
 #define ROBOT_DART_COMPILER_IGNORE_WARNINGS                                     \
     ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wold-style-cast")                \
     ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wzero-as-null-pointer-constant") \
@@ -17,13 +24,6 @@
     ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wpedantic")                      \
     ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wmissing-declarations")          \
     ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wunused-parameter")
-#else // #elif defined(__clang__)
-#define ROBOT_DART_COMPILER_IGNORE_WARNINGS                                     \
-    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wold-style-cast")                \
-    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wzero-as-null-pointer-constant") \
-    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wdeprecated-copy")               \
-    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wpedantic")                      \
-    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wmissing-declarations")
 #endif
 
 ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH

--- a/src/robot_dart/utils.hpp
+++ b/src/robot_dart/utils.hpp
@@ -15,7 +15,8 @@
     ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wzero-as-null-pointer-constant") \
     ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wdeprecated-copy")               \
     ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wpedantic")                      \
-    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wmissing-declarations")
+    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wmissing-declarations")          \
+    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wunused-parameter")
 #else // #elif defined(__GNUC__) || defined(__GNUG__)
 #define ROBOT_DART_COMPILER_IGNORE_WARNINGS                                     \
     ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wold-style-cast")                \

--- a/src/robot_dart/utils.hpp
+++ b/src/robot_dart/utils.hpp
@@ -5,14 +5,24 @@
 #include <exception>
 #include <iostream>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+#define ROBOT_DART_PRAGMA(x) _Pragma(#x)
+
+#define ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH ROBOT_DART_PRAGMA(GCC diagnostic push)
+#define ROBOT_DART_COMPILER_DIAGNOSTIC_POP ROBOT_DART_PRAGMA(GCC diagnostic pop)
+#define ROBOT_DART_COMPILER_IGNORE_WARNINGS                                     \
+    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wold-style-cast")                \
+    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wzero-as-null-pointer-constant") \
+    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wmaybe-uninitialized")           \
+    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wpedantic")                      \
+    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wmissing-declarations")
+
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
 #include <dart/config.hpp>
-#pragma GCC diagnostic pop
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 #ifndef ROBOT_DART_SHOW_WARNINGS
 #define ROBOT_DART_SHOW_WARNINGS true

--- a/src/robot_dart/utils.hpp
+++ b/src/robot_dart/utils.hpp
@@ -9,12 +9,22 @@
 
 #define ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH ROBOT_DART_PRAGMA(GCC diagnostic push)
 #define ROBOT_DART_COMPILER_DIAGNOSTIC_POP ROBOT_DART_PRAGMA(GCC diagnostic pop)
+#ifdef __GNUC__
 #define ROBOT_DART_COMPILER_IGNORE_WARNINGS                                     \
     ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wold-style-cast")                \
     ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wzero-as-null-pointer-constant") \
     ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wmaybe-uninitialized")           \
     ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wpedantic")                      \
+    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wmissing-declarations")          \
+    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wunused-parameter")
+#else // #elif defined(__clang__)
+#define ROBOT_DART_COMPILER_IGNORE_WARNINGS                                     \
+    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wold-style-cast")                \
+    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wzero-as-null-pointer-constant") \
+    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wdeprecated-copy")               \
+    ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wpedantic")                      \
     ROBOT_DART_PRAGMA(GCC diagnostic ignored "-Wmissing-declarations")
+#endif
 
 ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
 ROBOT_DART_COMPILER_IGNORE_WARNINGS

--- a/src/robot_dart/utils_headers_dart_collision.hpp
+++ b/src/robot_dart/utils_headers_dart_collision.hpp
@@ -1,0 +1,22 @@
+#ifndef ROBOT_DART_UTILS_HEADERS_DART_COLLISION_HPP
+#define ROBOT_DART_UTILS_HEADERS_DART_COLLISION_HPP
+
+#pragma GCC system_header
+
+#include <dart/config.hpp>
+
+#include <dart/collision/CollisionFilter.hpp>
+#include <dart/collision/CollisionObject.hpp>
+#include <dart/collision/dart/DARTCollisionDetector.hpp>
+#include <dart/collision/fcl/FCLCollisionDetector.hpp>
+#include <dart/constraint/ConstraintSolver.hpp>
+
+#if (HAVE_BULLET == 1)
+#include <dart/collision/bullet/BulletCollisionDetector.hpp>
+#endif
+
+#if (HAVE_ODE == 1)
+#include <dart/collision/ode/OdeCollisionDetector.hpp>
+#endif
+
+#endif

--- a/src/robot_dart/utils_headers_dart_dynamics.hpp
+++ b/src/robot_dart/utils_headers_dart_dynamics.hpp
@@ -1,0 +1,20 @@
+#ifndef ROBOT_DART_UTILS_HEADERS_DART_DYNAMICS_HPP
+#define ROBOT_DART_UTILS_HEADERS_DART_DYNAMICS_HPP
+
+#pragma GCC system_header
+
+#include <dart/dynamics/BallJoint.hpp>
+#include <dart/dynamics/BodyNode.hpp>
+#include <dart/dynamics/BoxShape.hpp>
+#include <dart/dynamics/DegreeOfFreedom.hpp>
+#include <dart/dynamics/EllipsoidShape.hpp>
+#include <dart/dynamics/EulerJoint.hpp>
+#include <dart/dynamics/FreeJoint.hpp>
+#include <dart/dynamics/MeshShape.hpp>
+#include <dart/dynamics/RevoluteJoint.hpp>
+#include <dart/dynamics/ShapeNode.hpp>
+#include <dart/dynamics/SoftBodyNode.hpp>
+#include <dart/dynamics/SoftMeshShape.hpp>
+#include <dart/dynamics/WeldJoint.hpp>
+
+#endif

--- a/src/robot_dart/utils_headers_dart_io.hpp
+++ b/src/robot_dart/utils_headers_dart_io.hpp
@@ -1,0 +1,23 @@
+#ifndef ROBOT_DART_UTILS_HEADERS_DART_IO_HPP
+#define ROBOT_DART_UTILS_HEADERS_DART_IO_HPP
+
+#pragma GCC system_header
+
+#include <dart/config.hpp>
+
+#if DART_VERSION_AT_LEAST(7, 0, 0)
+#include <dart/io/SkelParser.hpp>
+#include <dart/io/sdf/SdfParser.hpp>
+#include <dart/io/urdf/urdf.hpp>
+#else
+#include <dart/utils/SkelParser.hpp>
+#include <dart/utils/sdf/SdfParser.hpp>
+#include <dart/utils/urdf/urdf.hpp>
+
+// namespace alias for compatibility
+namespace dart {
+    namespace io = utils;
+}
+#endif
+
+#endif

--- a/src/robot_dart/utils_headers_external.hpp
+++ b/src/robot_dart/utils_headers_external.hpp
@@ -1,0 +1,14 @@
+#ifndef ROBOT_DART_UTILS_HEADERS_EXTERNAL_HPP
+#define ROBOT_DART_UTILS_HEADERS_EXTERNAL_HPP
+
+#pragma GCC system_header
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <dart/config.hpp>
+#include <dart/dynamics/MeshShape.hpp>
+#include <dart/dynamics/Skeleton.hpp>
+#include <dart/simulation/World.hpp>
+
+#endif

--- a/src/robot_dart/utils_headers_external_gui.hpp
+++ b/src/robot_dart/utils_headers_external_gui.hpp
@@ -1,0 +1,10 @@
+#ifndef ROBOT_DART_UTILS_HEADERS_EXTERNAL_GUI_HPP
+#define ROBOT_DART_UTILS_HEADERS_EXTERNAL_GUI_HPP
+
+#pragma GCC system_header
+
+#include <robot_dart/utils_headers_external.hpp>
+
+#include <Magnum/DartIntegration/World.h>
+
+#endif

--- a/src/tests/test_robot.cpp
+++ b/src/tests/test_robot.cpp
@@ -4,12 +4,15 @@
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include <robot_dart/robot.hpp>
+#include <robot_dart/utils.hpp>
+
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
 #include <dart/dynamics/BodyNode.hpp>
 #include <dart/dynamics/BoxShape.hpp>
 #include <dart/dynamics/EllipsoidShape.hpp>
-
-#include <robot_dart/robot.hpp>
-#include <robot_dart/utils.hpp>
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 using namespace robot_dart;
 

--- a/src/tests/test_robot.cpp
+++ b/src/tests/test_robot.cpp
@@ -6,13 +6,7 @@
 
 #include <robot_dart/robot.hpp>
 #include <robot_dart/utils.hpp>
-
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <dart/dynamics/BodyNode.hpp>
-#include <dart/dynamics/BoxShape.hpp>
-#include <dart/dynamics/EllipsoidShape.hpp>
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
+#include <robot_dart/utils_headers_dart_dynamics.hpp>
 
 using namespace robot_dart;
 

--- a/src/tests/test_robot.cpp
+++ b/src/tests/test_robot.cpp
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(test_actuators_and_dofs)
 
         // check simple dof setting
         auto dof_name = pexod->dof_name(5); // get DoF name of DoFu with index = 5
-        pexod->set_position_enforced({false}, {dof_name});
+        pexod->set_position_enforced(false, {dof_name});
         BOOST_CHECK(!pexod->position_enforced({dof_name})[0]);
     }
 
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(test_actuators_and_dofs)
 
         // check simple dof setting
         auto dof_name = pexod->dof_name(0); // get DoF name of DoF with index = 0
-        pexod->set_damping_coeffs({10.0}, {dof_name});
+        pexod->set_damping_coeffs(10.0, {dof_name});
         BOOST_CHECK(pexod->damping_coeffs({dof_name})[0] == 10.0);
     }
 
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE(test_actuators_and_dofs)
 
         // check simple dof setting
         auto dof_name = pexod->dof_name(3); // get DoF name of DoF with index = 3u
-        pexod->set_coulomb_coeffs({10.0}, {dof_name});
+        pexod->set_coulomb_coeffs(10.0, {dof_name});
         BOOST_CHECK(pexod->coulomb_coeffs({dof_name})[0] == 10.0);
     }
 
@@ -238,7 +238,7 @@ BOOST_AUTO_TEST_CASE(test_actuators_and_dofs)
 
         // check simple dof setting
         auto dof_name = pexod->dof_name(3); // get DoF name of DoF with index = 3u
-        pexod->set_spring_stiffnesses({10.0}, {dof_name});
+        pexod->set_spring_stiffnesses(10.0, {dof_name});
         BOOST_CHECK(pexod->spring_stiffnesses({dof_name})[0] == 10.0);
     }
 }

--- a/src/tests/test_sensors.cpp
+++ b/src/tests/test_sensors.cpp
@@ -4,15 +4,18 @@
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 
-#include <dart/dynamics/BodyNode.hpp>
-#include <dart/dynamics/Joint.hpp>
-
 #include <robot_dart/robot.hpp>
 #include <robot_dart/robot_dart_simu.hpp>
 #include <robot_dart/sensor/force_torque.hpp>
 #include <robot_dart/sensor/imu.hpp>
 #include <robot_dart/sensor/torque.hpp>
 #include <robot_dart/utils.hpp>
+
+ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
+ROBOT_DART_COMPILER_IGNORE_WARNINGS
+#include <dart/dynamics/BodyNode.hpp>
+#include <dart/dynamics/Joint.hpp>
+ROBOT_DART_COMPILER_DIAGNOSTIC_POP
 
 using namespace robot_dart;
 

--- a/src/tests/test_sensors.cpp
+++ b/src/tests/test_sensors.cpp
@@ -10,12 +10,7 @@
 #include <robot_dart/sensor/imu.hpp>
 #include <robot_dart/sensor/torque.hpp>
 #include <robot_dart/utils.hpp>
-
-ROBOT_DART_COMPILER_DIAGNOSTIC_PUSH
-ROBOT_DART_COMPILER_IGNORE_WARNINGS
-#include <dart/dynamics/BodyNode.hpp>
-#include <dart/dynamics/Joint.hpp>
-ROBOT_DART_COMPILER_DIAGNOSTIC_POP
+#include <robot_dart/utils_headers_dart_dynamics.hpp>
 
 using namespace robot_dart;
 

--- a/waf_tools/corrade.py
+++ b/waf_tools/corrade.py
@@ -202,9 +202,17 @@ def check_corrade(conf, *k, **kw):
     return 1
 
 @conf
-def corrade_enable_pedantic_flags(conf, corrade_var = 'Corrade'):
-    # this has to be called after check_corrade
-    conf.env['CXXFLAGS'] = list(set(conf.env['CXXFLAGS'] + conf.env['CXX_FLAGS_%s' % corrade_var]))
+def corrade_enable_pedantic_flags(conf):
+    corrade_flags = '-Wall \
+                    -Wextra \
+                    -Wold-style-cast \
+                    -Winit-self \
+                    -Werror=return-type \
+                    -Wmissing-declarations \
+                    -pedantic \
+                    -fvisibility=hidden'
+    corrade_flags = corrade_flags.split()
+    conf.env['CXXFLAGS'] = list(set(conf.env['CXXFLAGS'] + corrade_flags))
 
 
 # Corrade TestSuite

--- a/wscript
+++ b/wscript
@@ -136,8 +136,8 @@ def configure(conf):
             conf.env['CXXFLAGS'].remove('-std=c++0x')
         conf.env['CXXFLAGS'] = conf.env['CXXFLAGS'] + conf.env.CXXFLAGS_DART
     
-    # add the prefix
-    conf.env['CXXFLAGS'] = conf.env['CXXFLAGS']
+    # add strict flags for warnings
+    corrade.corrade_enable_pedantic_flags(conf)
     print(conf.env['CXXFLAGS'])
 
 def summary(bld):


### PR DESCRIPTION
This PR cleans the code a bit by introducing stricter warnings. Surprisingly, we had very few parts in our code that needed alteration.

~~**TO-DO left:** group includes and use `#pragma GCC system_header` instead of `#pragma GCC diagnostic push/pop`.~~