### PR TITLE
Allow to "break" sensors

### DIFF
--- a/src/python/robot.cpp
+++ b/src/python/robot.cpp
@@ -450,7 +450,7 @@ namespace robot_dart {
                     py::arg("box_name") = "box")
                 .def_static("create_box", static_cast<std::shared_ptr<Robot> (*)(const Eigen::Vector3d&, const Eigen::Isometry3d&, const std::string&, double, const Eigen::Vector4d&, const std::string&)>(&Robot::create_box),
                     py::arg("dims"),
-                    py::arg("tf") = Eigen::Isometry3d::Identity(),
+                    py::arg("tf"),
                     py::arg("type") = "free",
                     py::arg("mass") = 1.,
                     py::arg("color") = dart::Color::Red(1.0),
@@ -465,7 +465,7 @@ namespace robot_dart {
                     py::arg("ellipsoid_name") = "ellipsoid")
                 .def_static("create_ellipsoid", static_cast<std::shared_ptr<Robot> (*)(const Eigen::Vector3d&, const Eigen::Isometry3d&, const std::string&, double, const Eigen::Vector4d&, const std::string&)>(&Robot::create_ellipsoid),
                     py::arg("dims"),
-                    py::arg("tf") = Eigen::Isometry3d::Identity(),
+                    py::arg("tf"),
                     py::arg("type") = "free",
                     py::arg("mass") = 1.,
                     py::arg("color") = dart::Color::Red(1.0),

--- a/src/robot_dart/robot.hpp
+++ b/src/robot_dart/robot.hpp
@@ -277,7 +277,7 @@ namespace robot_dart {
 
         // helper functions
         static std::shared_ptr<Robot> create_box(const Eigen::Vector3d& dims,
-            const Eigen::Isometry3d& tf = Eigen::Isometry3d::Identity(), const std::string& type = "free",
+            const Eigen::Isometry3d& tf, const std::string& type = "free",
             double mass = 1.0, const Eigen::Vector4d& color = dart::Color::Red(1.0),
             const std::string& box_name = "box");
         // pose: 6D log_map
@@ -287,7 +287,7 @@ namespace robot_dart {
             const std::string& box_name = "box");
 
         static std::shared_ptr<Robot> create_ellipsoid(const Eigen::Vector3d& dims,
-            const Eigen::Isometry3d& tf = Eigen::Isometry3d::Identity(), const std::string& type = "free",
+            const Eigen::Isometry3d& tf, const std::string& type = "free",
             double mass = 1.0, const Eigen::Vector4d& color = dart::Color::Red(1.0),
             const std::string& ellipsoid_name = "ellipsoid");
         // pose: 6D log_map

--- a/src/robot_dart/sensor/sensor.cpp
+++ b/src/robot_dart/sensor/sensor.cpp
@@ -43,6 +43,14 @@ namespace robot_dart {
         void Sensor::set_pose(const Eigen::Isometry3d& tf) { _world_pose = tf; }
         const Eigen::Isometry3d& Sensor::pose() const { return _world_pose; }
 
+        void Sensor::detach() {
+            _attached_to_body = false;
+            _attached_to_joint = false;
+            _body_attached = NULL;
+            _joint_attached = NULL;
+            _active = false;
+        }
+
         void Sensor::refresh(double t)
         {
             if (_attaching_to_body && !_attached_to_body) {

--- a/src/robot_dart/sensor/sensor.cpp
+++ b/src/robot_dart/sensor/sensor.cpp
@@ -46,8 +46,8 @@ namespace robot_dart {
         void Sensor::detach() {
             _attached_to_body = false;
             _attached_to_joint = false;
-            _body_attached = NULL;
-            _joint_attached = NULL;
+            _body_attached = nullptr;
+            _joint_attached = nullptr;
             _active = false;
         }
 
@@ -122,7 +122,7 @@ namespace robot_dart {
         }
         const std::string& Sensor::attached_to() const
          { 
-            assert(_attached_to_body || _attached_to_joint);
+            ROBOT_DART_EXCEPTION_ASSERT(_attached_to_body || _attached_to_joint, "Joint is not attached to anything");
             if (_attached_to_body)
                 return _body_attached->getName();
             // attached to joint

--- a/src/robot_dart/sensor/sensor.cpp
+++ b/src/robot_dart/sensor/sensor.cpp
@@ -53,6 +53,8 @@ namespace robot_dart {
 
         void Sensor::refresh(double t)
         {
+            if (!_active)
+                return;
             if (_attaching_to_body && !_attached_to_body) {
                 attach_to_body(_body_attached, _attached_tf);
             }
@@ -79,7 +81,6 @@ namespace robot_dart {
                 if (body)
                     _world_pose = body->getWorldTransform() * tf * _attached_tf;
             }
-
             calculate(t);
         }
 
@@ -118,6 +119,14 @@ namespace robot_dart {
                 _attaching_to_joint = false;
                 _attached_to_joint = false;
             }
+        }
+        const std::string& Sensor::attached_to() const
+         { 
+            assert(_attached_to_body || _attached_to_joint);
+            if (_attached_to_body)
+                return _body_attached->getName();
+            // attached to joint
+            return _joint_attached->getName();
         }
     } // namespace sensor
 } // namespace robot_dart

--- a/src/robot_dart/sensor/sensor.hpp
+++ b/src/robot_dart/sensor/sensor.hpp
@@ -52,6 +52,7 @@ namespace robot_dart {
             virtual void attach_to_joint(dart::dynamics::Joint* joint, const Eigen::Isometry3d& tf = Eigen::Isometry3d::Identity());
             void attach_to_joint(const std::shared_ptr<Robot>& robot, const std::string& joint_name, const Eigen::Isometry3d& tf = Eigen::Isometry3d::Identity()) { attach_to_joint(robot->joint(joint_name), tf); }
 
+            void detach();
         protected:
             RobotDARTSimu* _simu = nullptr;
             bool _active;

--- a/src/robot_dart/sensor/sensor.hpp
+++ b/src/robot_dart/sensor/sensor.hpp
@@ -53,6 +53,7 @@ namespace robot_dart {
             void attach_to_joint(const std::shared_ptr<Robot>& robot, const std::string& joint_name, const Eigen::Isometry3d& tf = Eigen::Isometry3d::Identity()) { attach_to_joint(robot->joint(joint_name), tf); }
 
             void detach();
+            const std::string& attached_to() const;
         protected:
             RobotDARTSimu* _simu = nullptr;
             bool _active;

--- a/waf_tools/magnum.py
+++ b/waf_tools/magnum.py
@@ -213,12 +213,11 @@ def check_magnum(conf, *k, **kw):
             magnum_includes = magnum_includes + [opengl_include_dir]
             conf.end_msg(opengl_include_dir)
 
- #           conf.start_msg('Magnum: Checking for OpenGL lib')
-#            if conf.env['DEST_OS'] != 'darwin':
-                # opengl_lib_dir = get_directory('libGL.'+suffix, libs_check)
-                # magnum_libpaths = magnum_libpaths + [opengl_lib_dir]
-                # magnum_libs = magnum_libs + ['GL']
-                # conf.end_msg(['GL'])
+            conf.start_msg('Magnum: Checking for OpenGL lib')
+            opengl_lib_dir = get_directory('libGL.'+suffix, libs_check)
+            magnum_libpaths = magnum_libpaths + [opengl_lib_dir]
+            magnum_libs = magnum_libs + ['GL']
+            conf.end_msg(['GL'])
 
             conf.start_msg('Magnum: Checking for MagnumGL lib')
             gl_lib_dir = get_directory('libMagnumGL.'+suffix, libs_check)
@@ -295,7 +294,6 @@ def check_magnum(conf, *k, **kw):
                                 magnum_component_libs[component].append(lib_glfw)
                                 break
                             except:
-                                pass
                                 glfw_found = False
 
                         # GlfwApplication needs the libdl.so library
@@ -304,7 +302,6 @@ def check_magnum(conf, *k, **kw):
                             magnum_component_libpaths[component] = magnum_component_libpaths[component] + [lib_dir]
                             magnum_component_libs[component].append('dl')
                         except:
-                            pass
                             glfw_found = False
 
                         if not glfw_found:

--- a/waf_tools/magnum.py
+++ b/waf_tools/magnum.py
@@ -213,11 +213,12 @@ def check_magnum(conf, *k, **kw):
             magnum_includes = magnum_includes + [opengl_include_dir]
             conf.end_msg(opengl_include_dir)
 
-            conf.start_msg('Magnum: Checking for OpenGL lib')
-            opengl_lib_dir = get_directory('libGL.'+suffix, libs_check)
-            magnum_libpaths = magnum_libpaths + [opengl_lib_dir]
-            magnum_libs = magnum_libs + ['GL']
-            conf.end_msg(['GL'])
+ #           conf.start_msg('Magnum: Checking for OpenGL lib')
+#            if conf.env['DEST_OS'] != 'darwin':
+                # opengl_lib_dir = get_directory('libGL.'+suffix, libs_check)
+                # magnum_libpaths = magnum_libpaths + [opengl_lib_dir]
+                # magnum_libs = magnum_libs + ['GL']
+                # conf.end_msg(['GL'])
 
             conf.start_msg('Magnum: Checking for MagnumGL lib')
             gl_lib_dir = get_directory('libMagnumGL.'+suffix, libs_check)
@@ -294,6 +295,7 @@ def check_magnum(conf, *k, **kw):
                                 magnum_component_libs[component].append(lib_glfw)
                                 break
                             except:
+                                pass
                                 glfw_found = False
 
                         # GlfwApplication needs the libdl.so library
@@ -302,6 +304,7 @@ def check_magnum(conf, *k, **kw):
                             magnum_component_libpaths[component] = magnum_component_libpaths[component] + [lib_dir]
                             magnum_component_libs[component].append('dl')
                         except:
+                            pass
                             glfw_found = False
 
                         if not glfw_found:


### PR DESCRIPTION
When we split a skeleton, some sensors point to unavailable bodies (or the robot would have no access to the sensors on the detached skeleton).

This PR use the `_attached` boolean (which was already here) to be able detach a sensor explicitly (to avoid a segv when it was attached to something that does not exist anymore).

One idea is that it is up to the user to know what to do when a sensor is detached (e.g., replace with zero). So, the user should check that the sensor is attached when working with damage and querying sensors.