### PR TITLE
fix big_sur (osx 11.6) compilation

### DIFF
--- a/waf_tools/magnum.py
+++ b/waf_tools/magnum.py
@@ -213,15 +213,15 @@ def check_magnum(conf, *k, **kw):
             magnum_includes = magnum_includes + [opengl_include_dir]
             conf.end_msg(opengl_include_dir)
 
-            conf.start_msg('Magnum: Checking for OpenGL lib')
             # no need to check on osx (it works anyway)
             # Osx 11.3 (Big Sur) does not have libGL.dylib anymore (there is libGL.tbd)
             # but at any rate, OpenGL is a framework so checking the dylib is not really what we need
             if conf.env['DEST_OS'] != 'darwin':
+                conf.start_msg('Magnum: Checking for OpenGL lib')
                 opengl_lib_dir = get_directory('libGL.'+suffix, libs_check)
                 magnum_libpaths = magnum_libpaths + [opengl_lib_dir]
                 magnum_libs = magnum_libs + ['GL']
-            conf.end_msg(['GL'])
+                conf.end_msg(['GL'])
 
             conf.start_msg('Magnum: Checking for MagnumGL lib')
             gl_lib_dir = get_directory('libMagnumGL.'+suffix, libs_check)

--- a/waf_tools/magnum.py
+++ b/waf_tools/magnum.py
@@ -214,9 +214,13 @@ def check_magnum(conf, *k, **kw):
             conf.end_msg(opengl_include_dir)
 
             conf.start_msg('Magnum: Checking for OpenGL lib')
-            opengl_lib_dir = get_directory('libGL.'+suffix, libs_check)
-            magnum_libpaths = magnum_libpaths + [opengl_lib_dir]
-            magnum_libs = magnum_libs + ['GL']
+            # no need to check on osx (it works anyway)
+            # Osx 11.3 (Big Sur) does not have libGL.dylib anymore (there is libGL.tbd)
+            # but at any rate, OpenGL is a framework so checking the dylib is not really what we need
+            if conf.env['DEST_OS'] != 'darwin':
+                opengl_lib_dir = get_directory('libGL.'+suffix, libs_check)
+                magnum_libpaths = magnum_libpaths + [opengl_lib_dir]
+                magnum_libs = magnum_libs + ['GL']
             conf.end_msg(['GL'])
 
             conf.start_msg('Magnum: Checking for MagnumGL lib')
@@ -289,20 +293,20 @@ def check_magnum(conf, *k, **kw):
                             try:
                                 lib_dir = get_directory('lib'+lib_glfw+'.'+suffix, libs_check)
                                 glfw_found = True
-
                                 magnum_component_libpaths[component] = magnum_component_libpaths[component] + [lib_dir]
                                 magnum_component_libs[component].append(lib_glfw)
                                 break
                             except:
                                 glfw_found = False
 
-                        # GlfwApplication needs the libdl.so library
-                        try:
-                            lib_dir = get_directory('libdl.'+suffix, libs_check)
-                            magnum_component_libpaths[component] = magnum_component_libpaths[component] + [lib_dir]
-                            magnum_component_libs[component].append('dl')
-                        except:
-                            glfw_found = False
+                        # GlfwApplication needs the libdl.so library (except on mac)
+                        if conf.env['DEST_OS'] != 'darwin':
+                            try:
+                                lib_dir = get_directory('libdl.'+suffix, libs_check)
+                                magnum_component_libpaths[component] = magnum_component_libpaths[component] + [lib_dir]
+                                magnum_component_libs[component].append('dl')
+                            except:
+                                glfw_found = False
 
                         if not glfw_found:
                             fatal(required, 'Not found')


### PR DESCRIPTION
It mainly skip the check for OpenGL libs since this is a framework and Magnum already does its stuffs for this. I am not sure this works for older OS X version because it was working before without this fix. 

However, we do not have that many OS X users (except me).