### PR TITLE
cmake.in multiple inclusion

### DIFF
--- a/cmake/RobotDARTConfig.cmake.in
+++ b/cmake/RobotDARTConfig.cmake.in
@@ -4,10 +4,7 @@
 # add_executable(robot_dart_example example.cpp)
 # target_link_libraries(robot_dart_example RobotDART::Simu)
 
-if(__ROBOT_DART_CMAKE_FILE__)
-  return()
-endif()
-set(__ROBOT_DART_CMAKE_FILE__ TRUE)
+include_guard(DIRECTORY)
 
 
 include(CMakeFindDependencyMacro)

--- a/cmake/RobotDARTConfig.cmake.in
+++ b/cmake/RobotDARTConfig.cmake.in
@@ -4,28 +4,10 @@
 # add_executable(robot_dart_example example.cpp)
 # target_link_libraries(robot_dart_example RobotDART::Simu)
 
-####### Corresponds to @PACKAGE_INIT@  #######
-
-get_filename_component(PACKAGE_PREFIX_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)
-
-macro(set_and_check _var _file)
-  set(${_var} "${_file}")
-  if(NOT EXISTS "${_file}")
-    message(FATAL_ERROR "File or directory ${_file} referenced by variable ${_var} does not exist !")
-  endif()
-endmacro()
-
-macro(check_required_components _NAME)
-  foreach(comp ${${_NAME}_FIND_COMPONENTS})
-    if(NOT ${_NAME}_${comp}_FOUND)
-      if(${_NAME}_FIND_REQUIRED_${comp})
-        set(${_NAME}_FOUND FALSE)
-      endif()
-    endif()
-  endforeach()
-endmacro()
-
-####################################################################################
+if(__ROBOT_DART_CMAKE_FILE__)
+  return()
+endif()
+set(__ROBOT_DART_CMAKE_FILE__ TRUE)
 
 
 include(CMakeFindDependencyMacro)
@@ -71,43 +53,6 @@ set(RobotDART_LIBRARY_DIRS "@RobotDART_LIBRARY_DIRS@")
 set(RobotDART_LIBRARY ${RobotDART_LIBRARY_DIRS}/libRobotDARTSimu@RobotDART_LIB_TYPE@)
 set(RobotDART_LIBRARIES "Threads::Threads;Eigen3::Eigen;${DART_LIBRARIES}")
 
-
-
-# Check cmake version
-if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" LESS 2.6)
-   message(FATAL_ERROR "CMake >= 2.6.0 required")
-endif()
-cmake_policy(PUSH)
-cmake_policy(VERSION 2.6...3.20)
-
-# Protect against multiple inclusion, which would fail when already imported targets are added once more.
-set(_targetsDefined)
-set(_targetsNotDefined)
-set(_expectedTargets)
-foreach(_expectedTarget RobotDART::Simu RobotDART::Magnum)
-  list(APPEND _expectedTargets ${_expectedTarget})
-  if(NOT TARGET ${_expectedTarget})
-    list(APPEND _targetsNotDefined ${_expectedTarget})
-  endif()
-  if(TARGET ${_expectedTarget})
-    list(APPEND _targetsDefined ${_expectedTarget})
-  endif()
-endforeach()
-if("${_targetsDefined}" STREQUAL "${_expectedTargets}")
-  unset(_targetsDefined)
-  unset(_targetsNotDefined)
-  unset(_expectedTargets)
-  set(CMAKE_IMPORT_FILE_VERSION)
-  cmake_policy(POP)
-  return()
-endif()
-if(NOT "${_targetsDefined}" STREQUAL "")
-  message(FATAL_ERROR "Some (but not all) targets in this export set were already defined.\nTargets Defined: ${_targetsDefined}\nTargets not yet defined: ${_targetsNotDefined}\n")
-endif()
-unset(_targetsDefined)
-unset(_targetsNotDefined)
-unset(_expectedTargets)
-
 add_library(RobotDART::Simu INTERFACE IMPORTED)
 set_target_properties(RobotDART::Simu PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${RobotDART_INCLUDE_DIRS}"
@@ -145,11 +90,3 @@ find_package_handle_standard_args(
     RobotDART_LIBRARY_DIRS)
 
 mark_as_advanced(RobotDART_INCLUDE_DIRS RobotDART_LIBRARY_DIRS RobotDART_LIBRARY RobotDART_FOUND)
-
-if(CMAKE_VERSION VERSION_LESS 2.8.12)
-  message(FATAL_ERROR "This file relies on consumers using CMake 2.8.12 or greater.")
-endif()
-
-# Commands beyond this point should not need to know the version.
-set(CMAKE_IMPORT_FILE_VERSION)
-cmake_policy(POP)

--- a/cmake/RobotDARTConfig.cmake.in
+++ b/cmake/RobotDARTConfig.cmake.in
@@ -4,6 +4,30 @@
 # add_executable(robot_dart_example example.cpp)
 # target_link_libraries(robot_dart_example RobotDART::Simu)
 
+####### Corresponds to @PACKAGE_INIT@  #######
+
+get_filename_component(PACKAGE_PREFIX_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)
+
+macro(set_and_check _var _file)
+  set(${_var} "${_file}")
+  if(NOT EXISTS "${_file}")
+    message(FATAL_ERROR "File or directory ${_file} referenced by variable ${_var} does not exist !")
+  endif()
+endmacro()
+
+macro(check_required_components _NAME)
+  foreach(comp ${${_NAME}_FIND_COMPONENTS})
+    if(NOT ${_NAME}_${comp}_FOUND)
+      if(${_NAME}_FIND_REQUIRED_${comp})
+        set(${_NAME}_FOUND FALSE)
+      endif()
+    endif()
+  endforeach()
+endmacro()
+
+####################################################################################
+
+
 include(CMakeFindDependencyMacro)
 include(FindPackageHandleStandardArgs)
 
@@ -47,6 +71,43 @@ set(RobotDART_LIBRARY_DIRS "@RobotDART_LIBRARY_DIRS@")
 set(RobotDART_LIBRARY ${RobotDART_LIBRARY_DIRS}/libRobotDARTSimu@RobotDART_LIB_TYPE@)
 set(RobotDART_LIBRARIES "Threads::Threads;Eigen3::Eigen;${DART_LIBRARIES}")
 
+
+
+# Check cmake version
+if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" LESS 2.6)
+   message(FATAL_ERROR "CMake >= 2.6.0 required")
+endif()
+cmake_policy(PUSH)
+cmake_policy(VERSION 2.6...3.20)
+
+# Protect against multiple inclusion, which would fail when already imported targets are added once more.
+set(_targetsDefined)
+set(_targetsNotDefined)
+set(_expectedTargets)
+foreach(_expectedTarget RobotDART::Simu RobotDART::Magnum)
+  list(APPEND _expectedTargets ${_expectedTarget})
+  if(NOT TARGET ${_expectedTarget})
+    list(APPEND _targetsNotDefined ${_expectedTarget})
+  endif()
+  if(TARGET ${_expectedTarget})
+    list(APPEND _targetsDefined ${_expectedTarget})
+  endif()
+endforeach()
+if("${_targetsDefined}" STREQUAL "${_expectedTargets}")
+  unset(_targetsDefined)
+  unset(_targetsNotDefined)
+  unset(_expectedTargets)
+  set(CMAKE_IMPORT_FILE_VERSION)
+  cmake_policy(POP)
+  return()
+endif()
+if(NOT "${_targetsDefined}" STREQUAL "")
+  message(FATAL_ERROR "Some (but not all) targets in this export set were already defined.\nTargets Defined: ${_targetsDefined}\nTargets not yet defined: ${_targetsNotDefined}\n")
+endif()
+unset(_targetsDefined)
+unset(_targetsNotDefined)
+unset(_expectedTargets)
+
 add_library(RobotDART::Simu INTERFACE IMPORTED)
 set_target_properties(RobotDART::Simu PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${RobotDART_INCLUDE_DIRS}"
@@ -84,3 +145,11 @@ find_package_handle_standard_args(
     RobotDART_LIBRARY_DIRS)
 
 mark_as_advanced(RobotDART_INCLUDE_DIRS RobotDART_LIBRARY_DIRS RobotDART_LIBRARY RobotDART_FOUND)
+
+if(CMAKE_VERSION VERSION_LESS 2.8.12)
+  message(FATAL_ERROR "This file relies on consumers using CMake 2.8.12 or greater.")
+endif()
+
+# Commands beyond this point should not need to know the version.
+set(CMAKE_IMPORT_FILE_VERSION)
+cmake_policy(POP)

--- a/cmake/RobotDARTConfig.cmake.in
+++ b/cmake/RobotDARTConfig.cmake.in
@@ -6,7 +6,6 @@
 
 include_guard(DIRECTORY)
 
-
 include(CMakeFindDependencyMacro)
 include(FindPackageHandleStandardArgs)
 

--- a/cmake/UthequeConfig.cmake.in
+++ b/cmake/UthequeConfig.cmake.in
@@ -4,29 +4,11 @@
 # add_executable(your_example example.cpp)
 # target_link_libraries(your_example Utheque)
 
+if(__UTHEQUE_CMAKE_FILE__)
+  return()
+endif()
+set(__UTHEQUE_CMAKE_FILE__ TRUE)
 
-####### Corresponds to @PACKAGE_INIT@  #######
-
-get_filename_component(PACKAGE_PREFIX_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)
-
-macro(set_and_check _var _file)
-  set(${_var} "${_file}")
-  if(NOT EXISTS "${_file}")
-    message(FATAL_ERROR "File or directory ${_file} referenced by variable ${_var} does not exist !")
-  endif()
-endmacro()
-
-macro(check_required_components _NAME)
-  foreach(comp ${${_NAME}_FIND_COMPONENTS})
-    if(NOT ${_NAME}_${comp}_FOUND)
-      if(${_NAME}_FIND_REQUIRED_${comp})
-        set(${_NAME}_FOUND FALSE)
-      endif()
-    endif()
-  endforeach()
-endmacro()
-
-####################################################################################
 
 include(CMakeFindDependencyMacro)
 include(FindPackageHandleStandardArgs)
@@ -39,46 +21,6 @@ find_package(Boost REQUIRED filesystem)
 set(Utheque_INCLUDE_DIRS "@Utheque_INCLUDE_DIRS@")
 
 set(Utheque_LIBRARIES "Boost::filesystem")
-
-
-# Check cmake version
-if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" LESS 2.6)
-   message(FATAL_ERROR "CMake >= 2.6.0 required")
-endif()
-cmake_policy(PUSH)
-cmake_policy(VERSION 2.6...3.20)
-
-# Protect against multiple inclusion, which would fail when already imported targets are added once more.
-set(_targetsDefined)
-set(_targetsNotDefined)
-set(_expectedTargets)
-foreach(_expectedTarget Utheque)
-  list(APPEND _expectedTargets ${_expectedTarget})
-  if(NOT TARGET ${_expectedTarget})
-    list(APPEND _targetsNotDefined ${_expectedTarget})
-  endif()
-  if(TARGET ${_expectedTarget})
-    list(APPEND _targetsDefined ${_expectedTarget})
-  endif()
-endforeach()
-if("${_targetsDefined}" STREQUAL "${_expectedTargets}")
-  unset(_targetsDefined)
-  unset(_targetsNotDefined)
-  unset(_expectedTargets)
-  set(CMAKE_IMPORT_FILE_VERSION)
-  cmake_policy(POP)
-  return()
-endif()
-if(NOT "${_targetsDefined}" STREQUAL "")
-  message(FATAL_ERROR "Some (but not all) targets in this export set were already defined.\nTargets Defined: ${_targetsDefined}\nTargets not yet defined: ${_targetsNotDefined}\n")
-endif()
-unset(_targetsDefined)
-unset(_targetsNotDefined)
-unset(_expectedTargets)
-
-
-
-# Create imported target Utheque
 
 add_library(Utheque INTERFACE IMPORTED)
 set_target_properties(Utheque PROPERTIES
@@ -94,12 +36,3 @@ find_package_handle_standard_args(
     Utheque_INCLUDE_DIRS)
 
 mark_as_advanced(Utheque_INCLUDE_DIRS Utheque_FOUND)
-
-
-if(CMAKE_VERSION VERSION_LESS 2.8.12)
-  message(FATAL_ERROR "This file relies on consumers using CMake 2.8.12 or greater.")
-endif()
-
-# Commands beyond this point should not need to know the version.
-set(CMAKE_IMPORT_FILE_VERSION)
-cmake_policy(POP)

--- a/cmake/UthequeConfig.cmake.in
+++ b/cmake/UthequeConfig.cmake.in
@@ -4,6 +4,30 @@
 # add_executable(your_example example.cpp)
 # target_link_libraries(your_example Utheque)
 
+
+####### Corresponds to @PACKAGE_INIT@  #######
+
+get_filename_component(PACKAGE_PREFIX_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)
+
+macro(set_and_check _var _file)
+  set(${_var} "${_file}")
+  if(NOT EXISTS "${_file}")
+    message(FATAL_ERROR "File or directory ${_file} referenced by variable ${_var} does not exist !")
+  endif()
+endmacro()
+
+macro(check_required_components _NAME)
+  foreach(comp ${${_NAME}_FIND_COMPONENTS})
+    if(NOT ${_NAME}_${comp}_FOUND)
+      if(${_NAME}_FIND_REQUIRED_${comp})
+        set(${_NAME}_FOUND FALSE)
+      endif()
+    endif()
+  endforeach()
+endmacro()
+
+####################################################################################
+
 include(CMakeFindDependencyMacro)
 include(FindPackageHandleStandardArgs)
 
@@ -15,6 +39,46 @@ find_package(Boost REQUIRED filesystem)
 set(Utheque_INCLUDE_DIRS "@Utheque_INCLUDE_DIRS@")
 
 set(Utheque_LIBRARIES "Boost::filesystem")
+
+
+# Check cmake version
+if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" LESS 2.6)
+   message(FATAL_ERROR "CMake >= 2.6.0 required")
+endif()
+cmake_policy(PUSH)
+cmake_policy(VERSION 2.6...3.20)
+
+# Protect against multiple inclusion, which would fail when already imported targets are added once more.
+set(_targetsDefined)
+set(_targetsNotDefined)
+set(_expectedTargets)
+foreach(_expectedTarget Utheque)
+  list(APPEND _expectedTargets ${_expectedTarget})
+  if(NOT TARGET ${_expectedTarget})
+    list(APPEND _targetsNotDefined ${_expectedTarget})
+  endif()
+  if(TARGET ${_expectedTarget})
+    list(APPEND _targetsDefined ${_expectedTarget})
+  endif()
+endforeach()
+if("${_targetsDefined}" STREQUAL "${_expectedTargets}")
+  unset(_targetsDefined)
+  unset(_targetsNotDefined)
+  unset(_expectedTargets)
+  set(CMAKE_IMPORT_FILE_VERSION)
+  cmake_policy(POP)
+  return()
+endif()
+if(NOT "${_targetsDefined}" STREQUAL "")
+  message(FATAL_ERROR "Some (but not all) targets in this export set were already defined.\nTargets Defined: ${_targetsDefined}\nTargets not yet defined: ${_targetsNotDefined}\n")
+endif()
+unset(_targetsDefined)
+unset(_targetsNotDefined)
+unset(_expectedTargets)
+
+
+
+# Create imported target Utheque
 
 add_library(Utheque INTERFACE IMPORTED)
 set_target_properties(Utheque PROPERTIES
@@ -30,3 +94,12 @@ find_package_handle_standard_args(
     Utheque_INCLUDE_DIRS)
 
 mark_as_advanced(Utheque_INCLUDE_DIRS Utheque_FOUND)
+
+
+if(CMAKE_VERSION VERSION_LESS 2.8.12)
+  message(FATAL_ERROR "This file relies on consumers using CMake 2.8.12 or greater.")
+endif()
+
+# Commands beyond this point should not need to know the version.
+set(CMAKE_IMPORT_FILE_VERSION)
+cmake_policy(POP)

--- a/cmake/UthequeConfig.cmake.in
+++ b/cmake/UthequeConfig.cmake.in
@@ -4,11 +4,7 @@
 # add_executable(your_example example.cpp)
 # target_link_libraries(your_example Utheque)
 
-if(__UTHEQUE_CMAKE_FILE__)
-  return()
-endif()
-set(__UTHEQUE_CMAKE_FILE__ TRUE)
-
+include_guard(DIRECTORY)
 
 include(CMakeFindDependencyMacro)
 include(FindPackageHandleStandardArgs)

--- a/wscript
+++ b/wscript
@@ -402,7 +402,7 @@ def build_examples(bld):
     print("Bulding examples...")
     libs = 'BOOST EIGEN DART PTHREAD'
     path = bld.path.abspath() + '/res'
-    bld.env.LIB_PTHREAD = ['pthread']
+    bld.env.LIB_PTHREAD = ['pthread', 'tbb']
 
     # these examples should not be compiled without magnum
     magnum_only = ['magnum_contexts.cpp', 'cameras.cpp', 'transparent.cpp']
@@ -417,6 +417,9 @@ def build_examples(bld):
             ffile = os.path.join(root, filename)
             basename = filename.replace('.cpp', '')
             # plain version
+            cxxflags = ''
+            if basename == 'mpc':
+                cxxflags = '-ltbb'
             if (filename not in exclude) and (filename not in magnum_only):
                 bld.program(features = 'cxx',
                     install_path = None,


### PR DESCRIPTION
This PR allows the cmake.in to handle multiple inclusion case (when a library depends on several libraries that depend on  utheque / robot_dart)
Without it and in case of multiple inclusion there is an error at the  add_library stage because it has already been done
