### PR TITLE
In OSX do not search for GL headers

### DIFF
--- a/waf_tools/magnum.py
+++ b/waf_tools/magnum.py
@@ -197,26 +197,26 @@ def check_magnum(conf, *k, **kw):
 
         if 'TARGET_GL' in magnum_config:
             # to-do: make it work for other platforms; now only for desktop and only for GL
-            conf.start_msg('Magnum: Checking for OpenGL includes')
-            opengl_files = ['GL/gl.h', 'gl.h']
-            gl_not_found = False
-            for gl_file in opengl_files:
-                try:
-                    opengl_include_dir = get_directory(gl_file, includes_check)
-                    gl_not_found = False
-                    break
-                except:
-                    gl_not_found = True
-            if gl_not_found:
-                fatal(required, 'Not found')
-                return
-            magnum_includes = magnum_includes + [opengl_include_dir]
-            conf.end_msg(opengl_include_dir)
-
             # no need to check on osx (it works anyway)
             # Osx 11.3 (Big Sur) does not have libGL.dylib anymore (there is libGL.tbd)
             # but at any rate, OpenGL is a framework so checking the dylib is not really what we need
             if conf.env['DEST_OS'] != 'darwin':
+                conf.start_msg('Magnum: Checking for OpenGL includes')
+                opengl_files = ['GL/gl.h', 'gl.h']
+                gl_not_found = False
+                for gl_file in opengl_files:
+                    try:
+                        opengl_include_dir = get_directory(gl_file, includes_check)
+                        gl_not_found = False
+                        break
+                    except:
+                        gl_not_found = True
+                if gl_not_found:
+                    fatal(required, 'Not found')
+                    return
+                magnum_includes = magnum_includes + [opengl_include_dir]
+                conf.end_msg(opengl_include_dir)
+
                 conf.start_msg('Magnum: Checking for OpenGL lib')
                 opengl_lib_dir = get_directory('libGL.'+suffix, libs_check)
                 magnum_libpaths = magnum_libpaths + [opengl_lib_dir]


### PR DESCRIPTION
It appears that in recent versions of OSX, the GL headers are removed and not needed anymore. @jbmouret @Aneoshun  can you verify that this is working OK in your Mac PCs?