### PR TITLE
Add a warning message when policy is not set to active during configuration

### DIFF
--- a/src/robot_dart/control/policy_control.hpp
+++ b/src/robot_dart/control/policy_control.hpp
@@ -21,6 +21,8 @@ namespace robot_dart {
                 _policy.set_params(_ctrl);
                 if (_policy.output_size() == _control_dof)
                     _active = true;
+                else
+                    ROBOT_DART_WARNING(_policy.output_size() != _control_dof, "Control DoF != Policy output size. Policy is not active.");
                 auto robot = _robot.lock();
                 if (_full_dt)
                     _dt = robot->skeleton()->getTimeStep();


### PR DESCRIPTION
This PR adds a warning message when DoFs are different from the policy output size.

During configure() if these values are different, the policy is not set to active but there is no message and this goes unnoticed by the user as the robot still moves (I'm not sure where these motor commands come from).

There is an assert on calculate() with the same condition, but it is not triggered if the policy was not flagged as active during configure().