### PR TITLE
[tiago]: override reset function

### DIFF
--- a/src/python/robot.cpp
+++ b/src/python/robot.cpp
@@ -535,6 +535,7 @@ namespace robot_dart {
                     py::arg("frequency") = 1000,
                     py::arg("urdf") = "tiago/tiago_steel.urdf",
                     py::arg("packages") = std::vector<std::pair<std::string, std::string>>({{"tiago_description", "tiago/tiago_description"}}))
+                .def("reset", &Tiago::reset)
                 .def("ft_wrist", &Tiago::ft_wrist, py::return_value_policy::reference)
                 .def("caster_joints", &Tiago::caster_joints)
                 .def("set_actuator_types", &Tiago::set_actuator_types,

--- a/src/robot_dart/robot.hpp
+++ b/src/robot_dart/robot.hpp
@@ -59,7 +59,7 @@ namespace robot_dart {
         bool fixed() const;
         bool free() const;
 
-        void reset();
+        virtual void reset();
 
         void clear_external_forces();
         void clear_internal_forces();

--- a/src/robot_dart/robots/tiago.cpp
+++ b/src/robot_dart/robots/tiago.cpp
@@ -14,6 +14,13 @@ namespace robot_dart {
             set_actuator_types("servo");
         }
 
+        void Tiago::reset()
+        {
+            Robot::reset();
+            skeleton()->setPosition(2, M_PI / 2.);
+            skeleton()->setPosition(5, 0.);
+        }
+
         void Tiago::set_actuator_types(const std::string& type, const std::vector<std::string>& joint_names, bool override_mimic, bool override_base, bool override_caster)
         {
             auto jt = joint_names;

--- a/src/robot_dart/robots/tiago.hpp
+++ b/src/robot_dart/robots/tiago.hpp
@@ -11,6 +11,8 @@ namespace robot_dart {
         public:
             Tiago(size_t frequency = 1000, const std::string& urdf = "tiago/tiago_steel.urdf", const std::vector<std::pair<std::string, std::string>>& packages = {{"tiago_description", "tiago/tiago_description"}});
 
+            void reset() override;
+
             const sensor::ForceTorque& ft_wrist() const { return *_ft_wrist; }
 
             std::vector<std::string> caster_joints() const { return {"caster_back_left_2_joint", "caster_back_left_1_joint", "caster_back_right_2_joint", "caster_back_right_1_joint", "caster_front_left_2_joint", "caster_front_left_1_joint", "caster_front_right_2_joint", "caster_front_right_1_joint"}; }


### PR DESCRIPTION
For Tiago, calling `reset()` sets a different orientation than the constructor. This fixes it.