### PR TITLE
include string (create_compatibility_shader.hpp)

### DIFF
--- a/src/robot_dart/gui/magnum/gs/create_compatibility_shader.hpp
+++ b/src/robot_dart/gui/magnum/gs/create_compatibility_shader.hpp
@@ -27,6 +27,8 @@
 #include <Magnum/GL/Extensions.h>
 #include <Magnum/GL/Shader.h>
 
+#include <string>
+
 namespace robot_dart {
     namespace gui {
         namespace magnum {


### PR DESCRIPTION
The library's build failed after upgrading to the latest version of corrade and magnum via aur packages. However, the issue was resolved by including the string library in create_compatibility_shader.hpp. 