### PR TITLE
waf_tools/magnum: fix libdl detection

### DIFF
--- a/waf_tools/magnum.py
+++ b/waf_tools/magnum.py
@@ -354,6 +354,7 @@ def check_magnum(conf, *k, **kw):
                                     magnum_component_libs[component].append('dl')
 
                                     glfw_found = True
+                                    break
                                 except:
                                     glfw_found = False
 


### PR DESCRIPTION
fix libdl detection for magnum in waf_tools when libdl.so is found but not libdl.so.2, that was breaking the build in ubuntu18.04 at least.